### PR TITLE
tuple generator

### DIFF
--- a/pescador/core.py
+++ b/pescador/core.py
@@ -155,7 +155,7 @@ class Streamer(object):
             for item in self.generate():
                 yield item
 
-    def tuples(self, *items, max_batches=None):
+    def tuples(self, *items, **kwargs):
         '''Generate data in tuple-form instead of dicts.
 
         This is useful for interfacing with Keras's generator system,
@@ -193,5 +193,5 @@ class Streamer(object):
             raise PescadorError('Unable to generate tuples from '
                                 'an empty item set')
 
-        for data in self.generate(max_batches=max_batches):
+        for data in self.generate(**kwargs):
             yield tuple(data[item] for item in items)

--- a/pescador/core.py
+++ b/pescador/core.py
@@ -121,13 +121,13 @@ class Streamer(object):
         max_batches : None or int > 0
             Maximum number of batches to yield.
             If ``None``, exhaust the generator.
-            If the stream is finite, the generator
-            will be exausted when it complete. Call generate again,
-            or use cycle to force an infinite stream.
+            If the stream is finite, the generator will be
+            exhausted when it completes.
+            Call generate again, or use cycle to force an infinite stream.
 
         Yields
         ------
-        batch
+        batch : dict
             Items from the contained generator
             If `max_batches` is an integer, then at most
             `max_batches` are generated.
@@ -154,3 +154,44 @@ class Streamer(object):
         while True:
             for item in self.generate():
                 yield item
+
+    def tuples(self, *items, max_batches=None):
+        '''Generate data in tuple-form instead of dicts.
+
+        This is useful for interfacing with Keras's generator system,
+        which requires iterates to be provided as tuples.
+
+        Parameters
+        ----------
+        *items
+            One or more dictionary keys.
+            The generated tuples will correspond to
+            `(batch[item1], batch[item2], ..., batch[itemk])`
+            where `batch` is a single iterate produced by the
+            streamer.
+
+        max_batches : None or int > 0
+            Maximum number of batches to yield.
+            If ``None``, exhaust the generator.
+            If the stream is finite, the generator will be
+            exhausted when it completes.
+            Call generate again, or use cycle to force an infinite stream.
+
+        Yields
+        ------
+        batch : tuple
+            Items from the contained generator
+            If `max_batches` is an integer, then at most
+            `max_batches` are generated.
+
+        See Also
+        --------
+        generate
+        '''
+
+        if not items:
+            raise PescadorError('Unable to generate tuples from '
+                                'an empty item set')
+
+        for data in self.generate(max_batches=max_batches):
+            yield tuple(data[item] for item in items)

--- a/pescador/core.py
+++ b/pescador/core.py
@@ -170,6 +170,12 @@ class Streamer(object):
             where `batch` is a single iterate produced by the
             streamer.
 
+        cycle : bool
+            If `True`, then data is generated infinitely
+            using the `cycle` method.
+            Otherwise, data is generated according to the
+            `generate` method.
+
         max_batches : None or int > 0
             Maximum number of batches to yield.
             If ``None``, exhaust the generator.
@@ -187,11 +193,16 @@ class Streamer(object):
         See Also
         --------
         generate
+        cycle
         '''
 
         if not items:
             raise PescadorError('Unable to generate tuples from '
                                 'an empty item set')
 
-        for data in self.generate(**kwargs):
-            yield tuple(data[item] for item in items)
+        if kwargs.pop('cycle', False):
+            for data in self.cycle():
+                yield tuple(data[item] for item in items)
+        else:
+            for data in self.generate(**kwargs):
+                yield tuple(data[item] for item in items)

--- a/tests/test_mux_streams.py
+++ b/tests/test_mux_streams.py
@@ -17,6 +17,25 @@ def test_mux_single():
     assert list(reference) == list(estimate)
 
 
+@pytest.mark.parametrize('items',
+                         [['X'], ['Y'], ['X', 'Y'], ['Y', 'X'],
+                          pytest.mark.xfail([],
+                                            raises=pescador.PescadorError)])
+def test_mux_single_tuple(items):
+
+    stream = pescador.Streamer(T.md_generator, 2, 50, items=items)
+    reference = list(stream.generate())
+
+    mux = pescador.mux.Mux([stream], 1, with_replacement=False)
+    estimate = list(mux.tuples(*items))
+
+    assert len(reference) == len(estimate)
+    for r, e in zip(reference, estimate):
+        assert isinstance(e, tuple)
+        for item, value in zip(items, e):
+            assert np.allclose(r[item], value)
+
+
 def test_mux_empty():
     with pytest.raises(pescador.PescadorError):
         list(pescador.mux.Mux([], 1).generate())

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -21,6 +21,23 @@ def test_streamer_list():
         T.__eq_batch(b1, b2)
 
 
+@pytest.mark.parametrize('items',
+                         [['X'], ['Y'], ['X', 'Y'], ['Y', 'X'],
+                          pytest.mark.xfail([],
+                                            raises=pescador.PescadorError)])
+def test_streamer_tuple(items):
+
+    reference = [tuple(batch[it] for it in items)
+                 for batch in T.__zip_generator(10, 2, 3)]
+
+    query = list(pescador.Streamer(T.__zip_generator, 10, 2, 3).tuples(*items))
+
+    assert len(reference) == len(query)
+    for b1, b2 in zip(reference, query):
+        assert isinstance(b2, tuple)
+        T.__eq_lists(b1, b2)
+
+
 @pytest.mark.parametrize('n_max', [None, 10, 50, 100])
 @pytest.mark.parametrize('stream_size', [1, 2, 7])
 def test_streamer_finite(n_max, stream_size):

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -115,6 +115,33 @@ def test_streamer_cycle():
     assert (len(data_results) == count_max and all(data_results))
 
 
+@pytest.mark.parametrize('items',
+                         [['X'], ['Y'], ['X', 'Y'], ['Y', 'X'],
+                          pytest.mark.xfail([],
+                                            raises=pescador.PescadorError)])
+def test_streamer_cycle_tuples(items):
+    """Test that a limited streamer will die and restart automatically."""
+    stream_len = 10
+    streamer = pescador.Streamer(T.__zip_generator, 10, 2, 3)
+    assert streamer.stream_ is None
+
+    # Exhaust the stream once.
+    query = list(streamer.generate())
+    assert stream_len == len(query)
+
+    # Now, generate from it infinitely using cycle.
+    # We're going to assume "infinite" == > 5*stream_len
+    count_max = 5 * stream_len
+
+    data_results = []
+    kwargs = dict(cycle=True)
+    for i, x in enumerate(streamer.tuples(*items, **kwargs)):
+        data_results.append((isinstance(x, tuple)))
+        if (i + 1) >= count_max:
+            break
+    assert (len(data_results) == count_max and all(data_results))
+
+
 def test_streamer_bad_function():
 
     def __fail():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,12 +25,13 @@ def finite_generator(n, size=2, lag=None):
             time.sleep(lag)
 
 
-def md_generator(dimension, n, size=2):
+def md_generator(dimension, n, size=2, items='X'):
 
     shape = [size] * dimension
 
     for i in range(n):
-        yield {'X': i * np.ones(shape)[np.newaxis]}
+
+        yield {item: i * np.ones(shape)[np.newaxis] for item in items}
 
 
 def infinite_generator(size=2):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,9 +29,11 @@ def md_generator(dimension, n, size=2, items='X'):
 
     shape = [size] * dimension
 
+    M = len(items)
     for i in range(n):
 
-        yield {item: i * np.ones(shape)[np.newaxis] for item in items}
+        yield {item: i * M * np.ones(shape)[np.newaxis] + j
+               for j, item in enumerate(items)}
 
 
 def infinite_generator(size=2):

--- a/tests/test_zmq_streams.py
+++ b/tests/test_zmq_streams.py
@@ -32,7 +32,7 @@ def test_zmq_tuple(items):
     stream = pescador.Streamer(T.md_generator, 2, 50, items=items)
     reference = list(stream.generate())
 
-    zmq_stream = pescador.ZMQStreamer(stream)
+    zmq_stream = pescador.ZMQStreamer(stream, timeout=5)
 
     estimate = list(zmq_stream.tuples(*items))
 

--- a/tests/test_zmq_streams.py
+++ b/tests/test_zmq_streams.py
@@ -1,3 +1,5 @@
+import pytest
+import numpy as np
 import six
 import pescador
 import test_utils as T
@@ -6,24 +8,39 @@ import warnings
 warnings.simplefilter('always')
 
 
-def test_zmq():
+@pytest.mark.parametrize('copy', [False, True])
+@pytest.mark.parametrize('timeout', [None, 0.5, 2, 5])
+def test_zmq(copy, timeout):
+    stream = pescador.Streamer(T.finite_generator, 200, size=3, lag=0.001)
+    reference = list(stream.generate())
 
-    def __test(copy, timeout):
-        stream = pescador.Streamer(T.finite_generator, 200, size=3, lag=0.001)
+    zmq_stream = pescador.ZMQStreamer(stream, copy=copy, timeout=timeout)
 
-        reference = list(stream.generate())
+    for _ in range(3):
+        query = list(zmq_stream.generate())
+        assert len(reference) == len(query)
+        for b1, b2 in zip(reference, query):
+            T.__eq_batch(b1, b2)
 
-        zmq_stream = pescador.ZMQStreamer(stream, copy=copy, timeout=timeout)
 
-        for _ in range(3):
-            query = list(zmq_stream.generate())
-            assert len(reference) == len(query)
-            for b1, b2 in zip(reference, query):
-                T.__eq_batch(b1, b2)
+@pytest.mark.parametrize('items',
+                         [['X'], ['Y'], ['X', 'Y'], ['Y', 'X'],
+                          pytest.mark.xfail([],
+                                            raises=pescador.PescadorError)])
+def test_zmq_tuple(items):
 
-    for copy in [False, True]:
-        for timeout in [None, 0.5, 2, 5]:
-            yield __test, copy, timeout
+    stream = pescador.Streamer(T.md_generator, 2, 50, items=items)
+    reference = list(stream.generate())
+
+    zmq_stream = pescador.ZMQStreamer(stream)
+
+    estimate = list(zmq_stream.tuples(*items))
+
+    assert len(reference) == len(estimate)
+    for r, e in zip(reference, estimate):
+        assert isinstance(e, tuple)
+        for item, value in zip(items, e):
+            assert np.allclose(r[item], value)
 
 
 def test_zmq_align():

--- a/tests/test_zmq_streams.py
+++ b/tests/test_zmq_streams.py
@@ -32,7 +32,7 @@ def test_zmq_tuple(items):
     stream = pescador.Streamer(T.md_generator, 2, 50, items=items)
     reference = list(stream.generate())
 
-    zmq_stream = pescador.ZMQStreamer(stream, timeout=5)
+    zmq_stream = pescador.ZMQStreamer(stream, timeout=None)
 
     estimate = list(zmq_stream.tuples(*items))
 


### PR DESCRIPTION
This implements #56 , and provides a tuple generator interface for all streamer objects.

To-do:

- [x] core implementation
- [x] core unit test for streamer
- [x] integration tests for all derived classes
- [x] cyclic tuple support