### PR TITLE
Fixes #86 -- Re-iterating Muxes

### DIFF
--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -248,16 +248,14 @@ def test_critical_mux_of_rate_limited_muxes():
     assert set('abcdefghijkl') == set(count.keys())
 
 
-@pytest.mark.xfail(reason="Mux.iterate cannot return multiple iterators (#86)")
 def test_restart_mux():
     s1 = pescador.Streamer('abc')
     s2 = pescador.Streamer('def')
     mux = pescador.Mux([s1, s2], k=2, rate=None, revive=True,
                        with_replacement=False, random_state=1234)
-    assert list(mux(max_iter=100)) == list(mux(max_iter=100))
+    assert len(list(mux(max_iter=100))) == len(list(mux(max_iter=100)))
 
 
-@pytest.mark.xfail(reason="Mux.iterate cannot return multiple iterators (#86)")
 def test_sampled_mux_of_muxes():
 
     def _cycle(values):


### PR DESCRIPTION
Moves `Mux.distribution` to `Mux.distribution_` as active stream state, which is a more appropriate place for the data structure (since it's mutated while the Mux is active).

Open RFC regarding any other tests that'd be worth adding.