### PR TITLE
ZMQStreamer default time

### DIFF
--- a/pescador/zmq_stream.py
+++ b/pescador/zmq_stream.py
@@ -125,7 +125,7 @@ class ZMQStreamer(Streamer):
 
     def __init__(self, streamer,
                  min_port=49152, max_port=65535, max_tries=100,
-                 copy=False, timeout=None):
+                 copy=False, timeout=5):
         '''
         Parameters
         ----------
@@ -143,7 +143,9 @@ class ZMQStreamer(Streamer):
             Set `True` to enable data copying
 
         timeout : [optional] number > 0
-            Maximum time (in seconds) to wait before killing subprocesses
+            Maximum time (in seconds) to wait before killing subprocesses.
+            If `None`, then the streamer will wait indefinitely for
+            subprocesses to terminate.
         '''
         self.streamer = streamer
         self.min_port = min_port


### PR DESCRIPTION
This PR changes the default `ZMQStreamer` timeout from `None` (indefinite waiting) to `5` seconds.

It should not affect the behavior of samples generated by `ZMQStreamer`, since the timeout only kicks in when the streamer is finished consuming data.

TODO: document this properly.  It's mentioned in the docstring for `__init__`, but this doesn't get rolled into the class documentation in the sphinx build.  This might be an issue better handled in #83  though.