### PR TITLE
Documentation update for 1.1 [in progress].

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,7 +10,7 @@ API Reference
 
 Streamer
 --------
-.. autoclass:: Streamer
+.. autoclass:: pescador.Streamer
     :inherited-members:
     :special-members: __call__
 
@@ -18,20 +18,19 @@ Streamer
 
 Multiplexing
 ------------
-.. autoclass:: Mux
+.. autoclass:: pescador.Mux
     :inherited-members:
     :special-members: __call__
 
 Maps (Transformers)
-------------------
+-------------------
 .. automodule:: pescador.maps
-    :members:
 
 .. _ZMQStreamer:
 
 Parallel streaming
 ------------------
-.. autoclass:: ZMQStreamer
+.. autoclass:: pescador.ZMQStreamer
     :inherited-members:
     :special-members: __call__
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,16 +14,6 @@ Streamer
     :inherited-members:
     :special-members: __call__
 
-
-.. _BufferedStreamer:
-
-Buffered Streamers
-------------------
-.. autoclass:: BufferedStreamer
-    :inherited-members:
-    :special-members: __call__
-
-
 .. _Mux:
 
 Multiplexing
@@ -32,6 +22,10 @@ Multiplexing
     :inherited-members:
     :special-members: __call__
 
+Maps (Transformers)
+------------------
+.. automodule:: pescador.maps
+    :members:
 
 .. _ZMQStreamer:
 

--- a/docs/bufferedstreaming.rst
+++ b/docs/bufferedstreaming.rst
@@ -3,7 +3,7 @@
 Buffered Streaming
 ==================
 
-In a machine learning setting, it is common to train a model with multiple input datapoints simultaneously, in what are commonly referred to as "minibatches". To achieve this, pescador provides the :ref:`buffer_stream` map transformer, which will "buffer" your batches into fixed batch sizes.
+In a machine learning setting, it is common to train a model with multiple input datapoints simultaneously, in what are commonly referred to as "minibatches". To achieve this, pescador provides the :ref:`buffer_stream` map transformer, which will "buffer" a data stream into fixed batch sizes.
 
 Following up on the first example, we use the `noisy_samples` generator.
 
@@ -27,7 +27,7 @@ Following up on the first example, we use the `noisy_samples` generator.
 
 A few important points to note about using :ref:`buffer_stream`:
 
-    - :ref:`bufer_stream` will concatenate your arrays, adding a new sample dimension such that the first dimension contains the number of batches (`minibatch_size` in the above example.
+    - :ref:`bufer_stream` will concatenate your arrays, adding a new sample dimension such that the first dimension contains the number of batches (`minibatch_size` in the above example). e.g. if your samples are shaped (4, 5), a batch size of 10 will produce arrays shaped (10, 4, 5)
 
     - Each key in the batches generated will be concatenated (across all the samples buffered).
 
@@ -36,7 +36,7 @@ A few important points to note about using :ref:`buffer_stream`:
 .. code-block:: python
     :linenos:
     
-    batch_streamer = pescador.Stream(buffered_sample_gen)
+    batch_streamer = pescador.Streamer(buffered_sample_gen)
 
     # Generate batches as a streamer:
     for batch in batch_streamer:

--- a/docs/bufferedstreaming.rst
+++ b/docs/bufferedstreaming.rst
@@ -41,7 +41,7 @@ A few important points to note about using :ref:`pescador.maps.buffer_stream`:
     # Generate batches as a streamer:
     for batch in batch_streamer:
         # batch['X'].shape == (minibatch_size, ...)
-        # batch['Y'].shape == (minibatch_size,)
+        # batch['Y'].shape == (minibatch_size, 1)
         ...
 
 

--- a/docs/bufferedstreaming.rst
+++ b/docs/bufferedstreaming.rst
@@ -3,7 +3,7 @@
 Buffered Streaming
 ==================
 
-In a machine learning setting, it is common to train a model with multiple input datapoints simultaneously, in what are commonly referred to as "minibatches". To achieve this, pescador provides the :ref:`buffer_stream` map transformer, which will "buffer" a data stream into fixed batch sizes.
+In a machine learning setting, it is common to train a model with multiple input datapoints simultaneously, in what are commonly referred to as "minibatches". To achieve this, pescador provides the :ref:`pescador.maps.buffer_stream` map transformer, which will "buffer" a data stream into fixed batch sizes.
 
 Following up on the first example, we use the `noisy_samples` generator.
 
@@ -25,13 +25,13 @@ Following up on the first example, we use the `noisy_samples` generator.
 
 
 
-A few important points to note about using :ref:`buffer_stream`:
+A few important points to note about using :ref:`pescador.maps.buffer_stream`:
 
-    - :ref:`bufer_stream` will concatenate your arrays, adding a new sample dimension such that the first dimension contains the number of batches (`minibatch_size` in the above example). e.g. if your samples are shaped (4, 5), a batch size of 10 will produce arrays shaped (10, 4, 5)
+    - :ref:`pescador.maps.buffer_stream` will concatenate your arrays, adding a new sample dimension such that the first dimension contains the number of batches (`minibatch_size` in the above example). e.g. if your samples are shaped (4, 5), a batch size of 10 will produce arrays shaped (10, 4, 5)
 
     - Each key in the batches generated will be concatenated (across all the samples buffered).
 
-    - `buffer_stream`, like all `pescador.map` transformers, returns a *generator*, not a Streamer. So, if you still want it to behave like a streamer, you have to wrap it in a streamer. Following up on the previous example:
+    - `pescador.maps.buffer_stream`, like all `pescador.maps` transformers, returns a *generator*, not a Streamer. So, if you still want it to behave like a streamer, you have to wrap it in a streamer. Following up on the previous example:
 
 .. code-block:: python
     :linenos:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,9 @@ import matplotlib.pyplot as plt
 from glob import glob
 autosummary_generate = glob('*.rst')
 
+# Include the __init__ doc as well as the class
+autoclass_content = 'both'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ sphinx_gallery_conf = {
         'theano': 'http://deeplearning.net/software/theano/'
     },
     'default_thumb_file': 'noun_199.png',
+    'backreferences_dir': False,
 }
 
 import matplotlib as mpl

--- a/docs/example1.rst
+++ b/docs/example1.rst
@@ -40,7 +40,7 @@ Here's a simple example generator that draws random samples of data from the Iri
         sample : dict
             sample['X'] is an `np.ndarray` of shape `(d,)`
 
-            sample[Y'] is a scalar `np.ndarray` of shape `(,)`
+            sample['Y'] is a scalar `np.ndarray` of shape `(,)`
         '''
 
 
@@ -62,7 +62,7 @@ Streamers
 Generators in python have a couple of limitations for common stream learning pipelines.  First, once instantiated, a generator cannot be "restarted".  Second, an instantiated generator cannot be serialized
 directly, so they are difficult to use in distributed computation environments.
 
-Pescador provides the `Streamer` object to circumvent these issues.  `Streamer` simply provides an object container for an uninstantiated generator (and its parameters), and an access method `generate()`.  Calling `generate()` multiple times on a `Streamer` object is equivalent to restarting the generator, and can therefore be used to simply implement multiple pass streams.  Similarly, because `Streamer` can be serialized, it is simple to pass a streamer object to a separate process for parallel computation.
+Pescador provides the `Streamer` class to circumvent these issues.  `Streamer` simply provides an object container for an uninstantiated generator (and its parameters), and an access method `generate()`.  Calling `generate()` multiple times on a `Streamer` object is equivalent to restarting the generator, and can therefore be used to simply implement multiple pass streams.  Similarly, because `Streamer` can be serialized, it is simple to pass a streamer object to a separate process for parallel computation.
 
 Here's a simple example, using the generator from the previous section.
 

--- a/docs/example1.rst
+++ b/docs/example1.rst
@@ -7,78 +7,62 @@ This document will walk through the basics of using pescador to stream samples f
 
 Our running example will be learning from an infinite stream of stochastically perturbed samples from the Iris dataset.
 
-Before we can get started, we'll need to introduce a few core concepts.  
-We will assume some basic familiarity with `generators <https://wiki.python.org/moin/Generators>`_.
 
-
-Batch generators
+Sample generators
 ----------------
-Not all python generators are valid for machine learning.  Pescador assumes that generators produce output in
-a particular format, which we will refer to as a `batch`.  Specifically, a batch is a python dictionary
-containing `np.ndarray`.  For unsupervised learning (e.g., MiniBatchKMeans), valid batches contain only one
-key: `X`.  For supervised learning (e.g., SGDClassifier), valid batches must contain both `X` and `Y` keys,
-both of equal length.
+Streamers are intended to transparently pass data without modifying them. However, Pescador assumes that Streamers produce output in
+a particular format.  Specifically, a data is expected to be a python dictionary where each value contains a `np.ndarray`. For an unsupervised learning (e.g., SKLearn/`MiniBatchKMeans`), the data might contain only one
+key: `X`.  For supervised learning (e.g., SGDClassifier), valid data would contain both `X` and `Y` keys, both of equal length.
 
-Here's a simple example generator that draws random batches of data from Iris of a specified `batch_size`,
-and adds gaussian noise to the features.
+Here's a simple example generator that draws random samples of data from the Iris dataset, and adds gaussian noise to the features.
 
 .. code-block:: python
     :linenos:
 
     import numpy as np
 
-    def noisy_samples(X, Y, batch_size=16, sigma=1.0):
+    def noisy_samples(X, Y, sigma=1.0):
         '''Generate an infinite stream of noisy samples from a labeled dataset.
         
         Parameters
         ----------
-        X : np.ndarray, shape=(n, d)
+        X : np.ndarray, shape=(d,)
             Features
 
-        Y : np.ndarray, shape=(n,)
+        Y : np.ndarray, shape=(,)
             Labels
-
-        batch_size : int > 0
-            Size of the batches to generate
 
         sigma : float > 0
             Variance of the additive noise
 
         Yields
         ------
-        batch : dict
-            batch['X'] is an `np.ndarray` of shape `(batch_size, d)`
+        sample : dict
+            sample['X'] is an `np.ndarray` of shape `(d,)`
 
-            batch[Y'] is an `np.ndarray` of shape `(batch_size,)`
+            sample[Y'] is a scalar `np.ndarray` of shape `(,)`
         '''
 
 
         n, d = X.shape
 
         while True:
-            i = np.random.randint(0, n, size=batch_size)
+            i = np.random.randint(0, n)
 
-            noise = sigma * np.random.randn(batch_size, d)
+            noise = sigma * np.random.randn(1, d)
 
             yield dict(X=X[i] + noise, Y=Y[i])
 
 
-In the code above, `noisy_samples` is a generator that can be sampled indefinitely because `noisy_samples`
-contains an infinite loop.  Each iterate of `noisy_samples` will be a dictionary containing the sample batch's
-features and labels.
+In the code above, `noisy_samples` is a generator that can be sampled indefinitely because `noisy_samples` contains an infinite loop. Each iterate of `noisy_samples` will be a dictionary containing the sample's features and labels.
 
 
 Streamers
 ---------
-Generators in python have a couple of limitations for common stream learning pipelines.  First, once
-instantiated, a generator cannot be "restarted".  Second, an instantiated generator cannot be serialized
+Generators in python have a couple of limitations for common stream learning pipelines.  First, once instantiated, a generator cannot be "restarted".  Second, an instantiated generator cannot be serialized
 directly, so they are difficult to use in distributed computation environments.
 
-Pescador provides the `Streamer` object to circumvent these issues.  `Streamer` simply provides an object
-container for an uninstantiated generator (and its parameters), and an access method `generate()`.  Calling
-`generate()` multiple times on a streamer object is equivalent to restarting the generator, and can therefore
-be used to simply implement multiple pass streams.  Similarly, because `Streamer` can be serialized, it is
-simple to pass a streamer object to a separate process for parallel computation.
+Pescador provides the `Streamer` object to circumvent these issues.  `Streamer` simply provides an object container for an uninstantiated generator (and its parameters), and an access method `generate()`.  Calling `generate()` multiple times on a `Streamer` object is equivalent to restarting the generator, and can therefore be used to simply implement multiple pass streams.  Similarly, because `Streamer` can be serialized, it is simple to pass a streamer object to a separate process for parallel computation.
 
 Here's a simple example, using the generator from the previous section.
 
@@ -89,14 +73,13 @@ Here's a simple example, using the generator from the previous section.
 
     streamer = pescador.Streamer(noisy_samples, X[train], Y[train])
 
-    batch_stream2 = streamer.generate()
+    stream2 = streamer.iterate()
 
-Iterating over `streamer.generate()` is equivalent to iterating over `noisy_samples(X[train], Y[train])`.
+Iterating over `streamer.iterate()` is equivalent to iterating over `noisy_samples(X[train], Y[train])`.
 
-Additionally, Streamer can be bounded easily by saying `streamer.generate(max_batches=N)` for some `N` maximum number of batches.
+Additionally, Streamer can be bounded easily by saying `streamer.iterate(max_iter=N)` for some `N` maximum number of samples.
 
-Finally, because `generate()` is such a common operation with streamer objects, a short-hand interface is
-provided by treating the streamer object as if it was a generator:
+Finally, because `iterate()` is such a common operation with streamer objects, a short-hand interface is provided by treating the streamer object as if it was a generator:
 
 .. code-block:: python
     :linenos:
@@ -105,6 +88,20 @@ provided by treating the streamer object as if it was a generator:
 
     streamer = pescador.Streamer(noisy_samples, X[train], Y[train])
 
-    # Equivalent to batch_stream2 above
-    batch_stream3 = streamer()
+    # Equivalent to stream2 above
+    stream3 = streamer()
 
+
+Iterating over any of these would then look like the following:
+
+.. code-block:: python
+    ::linenos:
+
+    for sample in streamer.iterate():
+        # do something
+        ...
+
+    # For convenience, the object directly behaves as an iterator.
+    for sample in streamer:
+        # do something
+        ...

--- a/docs/example1.rst
+++ b/docs/example1.rst
@@ -1,7 +1,7 @@
 .. _example1:
 
 Basic example
-==============
+=============
 
 This document will walk through the basics of using pescador to stream samples from a generator.
 
@@ -9,7 +9,7 @@ Our running example will be learning from an infinite stream of stochastically p
 
 
 Sample generators
-----------------
+-----------------
 Streamers are intended to transparently pass data without modifying them. However, Pescador assumes that Streamers produce output in
 a particular format.  Specifically, a data is expected to be a python dictionary where each value contains a `np.ndarray`. For an unsupervised learning (e.g., SKLearn/`MiniBatchKMeans`), the data might contain only one
 key: `X`.  For supervised learning (e.g., SGDClassifier), valid data would contain both `X` and `Y` keys, both of equal length.
@@ -95,7 +95,7 @@ Finally, because `iterate()` is such a common operation with streamer objects, a
 Iterating over any of these would then look like the following:
 
 .. code-block:: python
-    ::linenos:
+    :linenos:
 
     for sample in streamer.iterate():
         # do something

--- a/docs/example2.rst
+++ b/docs/example2.rst
@@ -42,7 +42,8 @@ As a concrete example, we can simulate a mixture of noisy streams with differing
 
     classes = np.unique(Y)
 
-    for train, test in ShuffleSplit(len(X), n_splits=1, test_size=0.1):
+    rs = ShuffleSplit(n_splits=1, test_size=0.1)
+    for train, test in rs.split(X):
 
         # Instantiate a linear classifier
         estimator = SGDClassifier()
@@ -54,7 +55,7 @@ As a concrete example, we can simulate a mixture of noisy streams with differing
         # Build a mux stream, keeping 3 streams alive at once
         mux_stream = Mux(streams,
                          k=3,    # Keep 3 streams alive at once
-                         lam=64) # Use a poisson rate of 64
+                         rate=64) # Use a poisson rate of 64
 
         # Fit the model to the stream, use at most 5000 samples
         for sample in mux_stream(max_iter=5000):

--- a/docs/example2.rst
+++ b/docs/example2.rst
@@ -7,8 +7,7 @@ We will assume a working understanding of the simple example in the previous sec
 Stream re-use and multiplexing
 ==============================
 
-The `Mux` streamer provides a powerful interface for randomly interleaving samples from multiple input streams. 
-`Mux` can also dynamically activate and deactivate individual `Streamers`, which allows it to operate on a bounded subset of streams at any given time.
+The `Mux` streamer provides a powerful interface for randomly interleaving samples from multiple input streams. `Mux` can also dynamically activate and deactivate individual `Streamers`, which allows it to operate on a bounded subset of streams at any given time.
 
 As a concrete example, we can simulate a mixture of noisy streams with differing variances.
 
@@ -26,14 +25,14 @@ As a concrete example, we can simulate a mixture of noisy streams with differing
 
     from pescador import Streamer, Mux
 
-    def noisy_samples(X, Y, batch_size=16, sigma=1.0):
+    def noisy_samples(X, Y, sigma=1.0):
         '''Copied over from the previous example'''
         n, d = X.shape
 
         while True:
-            i = np.random.randint(0, n, size=batch_size)
+            i = np.random.randint(0, n, size=1)
 
-            noise = sigma * np.random.randn(batch_size, d)
+            noise = sigma * np.random.randn(1, d)
 
             yield dict(X=X[i] + noise, Y=Y[i])
 
@@ -57,26 +56,23 @@ As a concrete example, we can simulate a mixture of noisy streams with differing
                          k=3,    # Keep 3 streams alive at once
                          lam=64) # Use a poisson rate of 64
 
-        # Fit the model to the stream, use at most 5000 batches
-        for batch in mux_stream(max_batches=5000):
-            estimator.partial_fit(batch['X'], batch['Y'], classes=classes)
+        # Fit the model to the stream, use at most 5000 samples
+        for sample in mux_stream(max_iter=5000):
+            estimator.partial_fit(sample['X'], sample['Y'], classes=classes)
 
         # And report the accuracy
         Ypred = estimator.predict(X[test])
         print('Test accuracy: {:.3f}'.format(accuracy_score(Y[test], Ypred)))
 
 
-In the above example, each `Streamer` in `streams` can make infinitely many samples.
-The `lam=64` argument to `Mux` says that each stream should produce some `n` batches, where `n` is sampled from a Poisson distribution of rate `lam`.
-When a stream exceeds its bound, it is deactivated, and a new streamer is activated to fill its place.
+In the above example, each `Streamer` in `streams` can make infinitely many samples. The `rate=64` argument to `Mux` says that each stream should produce some `n` samples, where `n` is sampled from a Poisson distribution of rate `rate`. When a stream exceeds its bound, it is deactivated, and a new streamer is activated to fill its place.
 
-Setting `lam=None` disables the random stream bounding, and `mux()` simply runs each active stream until
-exhaustion.
+Setting `rate=None` disables the random stream bounding, and `mux()` simply runs each active stream until exhaustion.
 
 The `Mux` streamer can sampled with or without replacement from its input streams, according to the `with_replacement` option.
 Setting this parameter to `False` means that each stream can be active at most once.
 
-Streams can also be sampled with non-uniform weighting by specifying a vector of `pool_weights`.
+Streams can also be sampled with non-uniform weighting by specifying a vector of `weights`.
 
-Finally, exhausted streams can be removed by setting `prune_empty_seeds` to `True`.
+Finally, exhausted streams can be removed by setting `prune_empty_streams` to `True`.
 If `False`, then exhausted streams may be reactivated at any time.

--- a/docs/example3.rst
+++ b/docs/example3.rst
@@ -3,14 +3,7 @@
 Sampling from disk
 ==================
 
-A common use case for `pescador` is to sample data from a large collection of existing archives.
-As a concrete example, consider the problem of fitting a statistical model to a large
-corpus of musical recordings.
-When the corpus is sufficiently large, it is impossible to fit the entire set in memory
-while estimating the model parameters.
-Instead, one can pre-process each song to store pre-computed features (and, optionally,
-target labels) in a *numpy zip* `NPZ` archive.
-The problem then becomes sampling data from a collection of `NPZ` archives.
+A common use case for `pescador` is to sample data from a large collection of existing archives. As a concrete example, consider the problem of fitting a statistical model to a large corpus of musical recordings. When the corpus is sufficiently large, it is impossible to fit the entire set in memory while estimating the model parameters. Instead, one can pre-process each song to store pre-computed features (and, optionally, target labels) in a *numpy zip* `NPZ` archive. The problem then becomes sampling data from a collection of `NPZ` archives.
 
 Here, we will assume that the pre-processing has already been done so that each `NPZ` file contains a numpy array of features `X` and labels `Y`.
 We will define infinite samplers that pull `n` examples per iterate.
@@ -37,8 +30,7 @@ We will define infinite samplers that pull `n` examples per iterate.
                 yield dict(X=data['X'][idx:idx + n],
                            Y=data['Y'][idx:idx + n])
 
-Applying the `sample_npz` function above to a list of `npz_files`, we can make a
-multiplexed streamer object as follows:
+Applying the `sample_npz` function above to a list of `npz_files`, we can make a multiplexed streamer object as follows:
 
 .. code-block:: python
 
@@ -48,9 +40,9 @@ multiplexed streamer object as follows:
 
     # Keep 32 streams alive at once
     # Draw on average 16 patches from each stream before deactivating
-    mux_stream = pescador.Mux(streams, k=32, lam=16)
+    mux_stream = pescador.Mux(streams, k=32, rate=16)
 
-    for batch in mux_stream(max_batches=1000):
+    for batch in mux_stream(max_iter=1000):
         # DO LEARNING HERE
         pass
 
@@ -58,10 +50,7 @@ multiplexed streamer object as follows:
 Memory-mapping
 --------------
 
-The `NPZ` file format requires loading the entire contents of each archive into memory.
-This can lead to high memory consumption when the number of active streams is large.
-Note also that memory usage for each `NPZ` file will persist for as long as there is a reference to its contents.
-This can be circumvented, at the cost of some latency, by copying data within the streamer function:
+The `NPZ` file format requires loading the entire contents of each archive into memory. This can lead to high memory consumption when the number of active streams is large. Note also that memory usage for each `NPZ` file will persist for as long as there is a reference to its contents. This can be circumvented, at the cost of some latency, by copying data within the streamer function:
 
 .. code-block:: python
 
@@ -105,3 +94,7 @@ Alternatively, *memory-mapping* can be used to only load data as needed, but req
     streams = [pescador.Streamer(sample_npz, npy_x, npy_y n)
                for (npy_x, npy_y) in zip(npy_x_files, npy_y_files)]
 
+    # Then construct the `Mux` from the streams, as above
+    mux_streame = pescador.Mux(streams, k=32, rate=16)
+
+    ...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,9 +19,11 @@ The basic use case is as follows:
 
 On top of this basic functionality, pescador provides the following tools:
 
-    - Buffering of sampled data into fixed-size batches (see :ref:`BufferedStreamer`)
-    - Multiplexing multiple data streams with dynamic (see :ref:`Mux`)
+    - A :ref:`Streamer` allows you to turn a finite-lifecycle generator into an infinte stream with `cycle()`, by automatically restarting the generator if it completes.
+    - Multiplexing multiple data streams (see :ref:`Mux`)
+    - Transform or modify streams with Maps (see :ref:`Processing Data Streams`)
     - Parallel processing (see :ref:`ZMQStreamer`)
+    - Buffering of sampled data into fixed-size batches (see :ref:`buffer_stream`)
 
 For examples of each of these use-cases, refer to the :ref:`Examples` section.
 
@@ -29,7 +31,7 @@ For examples of each of these use-cases, refer to the :ref:`Examples` section.
 Definitions
 -----------
 
-Pescador is designed with the following notions in mind, with references to relevant documentation where appropriate:
+Pescador is designed with the following core principles:
 
 1. An "iterator" is an object that produces a sequence of data, i.e. via `__next__` / `next()`. (`Glossary definition <https://docs.python.org/3/glossary.html#term-iterator>`_, `Iterator Types <https://docs.python.org/3/library/stdtypes.html#typeiter>`_)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,9 +21,9 @@ On top of this basic functionality, pescador provides the following tools:
 
     - A :ref:`Streamer` allows you to turn a finite-lifecycle generator into an infinte stream with `cycle()`, by automatically restarting the generator if it completes.
     - Multiplexing multiple data streams (see :ref:`Mux`)
-    - Transform or modify streams with Maps (see :ref:`Processing Data Streams`)
+    - Transform or modify streams with Maps (see :ref:`processing-data-streams`)
     - Parallel processing (see :ref:`ZMQStreamer`)
-    - Buffering of sampled data into fixed-size batches (see :ref:`buffer_stream`)
+    - Buffering of sampled data into fixed-size batches (see :ref:`pescador.maps.buffer_stream`)
 
 For examples of each of these use-cases, refer to the :ref:`Examples` section.
 
@@ -33,18 +33,20 @@ Definitions
 
 Pescador is designed with the following core principles:
 
-1. An "iterator" is an object that produces a sequence of data, i.e. via `__next__` / `next()`. (`Glossary definition <https://docs.python.org/3/glossary.html#term-iterator>`_, `Iterator Types <https://docs.python.org/3/library/stdtypes.html#typeiter>`_)
+1. An "iterator" is an object that produces a sequence of data, i.e. via `__next__` / `next()`. (`iterator definition <https://docs.python.org/3/glossary.html#term-iterator>`_, `Iterator Types <https://docs.python.org/3/library/stdtypes.html#typeiter>`_)
 
-2. An "iterable" is an object that can produce iterators, i.e. via `__iter__` / `iter()`. (`Glossary definition <https://docs.python.org/3/glossary.html#term-iterable>`_)
+2. An "iterable" is an object that can produce iterators, i.e. via `__iter__` / `iter()`. (`iterable definition <https://docs.python.org/3/glossary.html#term-iterable>`_)
 
 3. A "stream" is the sequence of objects produced by an iterator.
 
-4. A "generator" (or more precisely "generator function") is a callable object that returns a single generator iterator. (`Glossary definition <https://docs.python.org/3/glossary.html#term-generator>`_)
+4. A "generator" (or more precisely "generator function") is a callable object that returns a single generator iterator. (`generator definition <https://docs.python.org/3/glossary.html#term-generator>`_)
 
 For example:
     - `range` is an iterable function
     - `range(8)` is an iterable, and its iterator produces the stream (consecutively) `0, 1, 2, 3, ...`
 
+
+.. _streaming-data:
 
 Streaming Data
 --------------
@@ -60,7 +62,7 @@ Streaming Data
 
     - A `Streamer` should not modify objects in its stream.
 
-    - In the spirit of encapsulation, the modification of data streams is achieved through separate functionality (see :ref:`Processing Data Streams`)
+    - In the spirit of encapsulation, the modification of data streams is achieved through separate functionality (see :ref:`processing-data-streams`)
 
 
 Multiplexing Data Streams
@@ -71,8 +73,10 @@ Multiplexing Data Streams
 
 3. A `Mux` is initialized with a container of one or more iterables, and parameters to control the stochastic behavior of the object.
 
-4. As a subclass of `Streamer`, a `Mux` also transparently yields the stream flowing through it, i.e. :ref:`Streaming Data`-4.
+4. As a subclass of `Streamer`, a `Mux` also transparently yields the stream flowing through it, i.e. :ref:`streaming-data`.
 
+
+.. _processing-data-streams:
 
 Processing Data Streams
 -----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,65 @@ On top of this basic functionality, pescador provides the following tools:
 For examples of each of these use-cases, refer to the :ref:`Examples` section.
 
 
+Definitions
+-----------
+
+Pescador is designed with the following notions in mind, with references to relevant documentation where appropriate:
+
+1. An "iterator" is an object that produces a sequence of data, i.e. via `__next__` / `next()`. (`Glossary definition <https://docs.python.org/3/glossary.html#term-iterator>`_, `Iterator Types <https://docs.python.org/3/library/stdtypes.html#typeiter>`_)
+
+2. An "iterable" is an object that can produce iterators, i.e. via `__iter__` / `iter()`. (`Glossary definition <https://docs.python.org/3/glossary.html#term-iterable>`_)
+
+3. A "stream" is the sequence of objects produced by an iterator.
+
+4. A "generator" (or more precisely "generator function") is a callable object that returns a single generator iterator. (`Glossary definition <https://docs.python.org/3/glossary.html#term-generator>`_)
+
+For example:
+    - `range` is an iterable function
+    - `range(8)` is an iterable, and its iterator produces the stream (consecutively) `0, 1, 2, 3, ...`
+
+
+Streaming Data
+--------------
+1. Pescador defines an object called a `Streamer` for the purposes of (re)creating iterators indefinitely and (optionally) interrupting them prematurely.
+
+2. `Streamer` inherits from `iterable` and can be iterated directly.
+
+3. A `Streamer` can be initialized with one of two types:
+    - Any iterable type, e.g. `range(7)`, `['foo', 'bar']`, `"abcdef"`, or another `Streamer()`
+    - A generator function and its arguments + keyword arguments.
+
+4. A `Streamer` transparently yields the data stream flowing through it
+
+    - A `Streamer` should not modify objects in its stream.
+
+    - In the spirit of encapsulation, the modification of data streams is achieved through separate functionality (see :ref:`Processing Data Streams`)
+
+
+Multiplexing Data Streams
+-------------------------
+1. Pescador defines an object called a `Mux` for the purposes of stochastically multiplexing streams of data.
+
+2. `Mux` inherits from `Streamer`, which makes it both iterable and recomposable, e.g. one can construct arbitrary trees of data streams.
+
+3. A `Mux` is initialized with a container of one or more iterables, and parameters to control the stochastic behavior of the object.
+
+4. As a subclass of `Streamer`, a `Mux` also transparently yields the stream flowing through it, i.e. :ref:`Streaming Data`-4.
+
+
+Processing Data Streams
+-----------------------
+Pescador adopts the concept of "transformers" for processing data streams.
+
+1. A transformer takes as input a single object in the stream.
+
+2. A transformer yields an object.
+
+3. Transformers are iterators, i.e. implement a `__next__` method, to preserve iteration.
+
+4. An example of a built-in transformer is `enumerate` [`ref <https://docs.python.org/3.3/library/functions.html#enumerate>`_]
+
+
 Basic Usage
 --------------
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@ Streaming Data
 
 Multiplexing Data Streams
 -------------------------
-1. Pescador defines an object called a `Mux` for the purposes of stochastically multiplexing streams of data.
+1. Pescador defines an object called a `Mux` for the purposes of multiplexing streams of data.
 
 2. `Mux` inherits from `Streamer`, which makes it both iterable and recomposable, e.g. one can construct arbitrary trees of data streams.
 

--- a/pescador/buffered.py
+++ b/pescador/buffered.py
@@ -8,7 +8,9 @@ from . import util
 
 
 class BufferedStreamer(core.Streamer):
-    """Buffers a stream into batches of examples
+    """Deprecated in 1.1. Will be removed in 2.0.
+
+    Buffers a stream into batches of examples.
 
     Examples
     --------

--- a/pescador/buffered.py
+++ b/pescador/buffered.py
@@ -8,9 +8,7 @@ from . import util
 
 
 class BufferedStreamer(core.Streamer):
-    """Deprecated in 1.1. Will be removed in 2.0.
-
-    Buffers a stream into batches of examples.
+    """Buffers a stream into batches of examples.
 
     Examples
     --------

--- a/pescador/core.py
+++ b/pescador/core.py
@@ -59,20 +59,24 @@ class Streamer(object):
     >>> for i in stream:
     ...     print(i)  # Displays 0, 1, 2, 3, 4
 
+
     Or with a maximum number of items
 
     >>> for i in stream(max_items=3):
     ...     print(i)  # Displays 0, 1, 2
+
 
     Or infinitely many examples, restarting the generator as needed
 
     >>> for i in stream.cycle():
     ...     print(i)  # Displays 0, 1, 2, 3, 4, 0, 1, 2, ...
 
+
     An alternate interface for the same:
 
     >>> for i in stream(cycle=True):
     ...     print(i)  # Displays 0, 1, 2, 3, 4, 0, 1, 2, ...
+
     '''
 
     def __init__(self, streamer, *args, **kwargs):
@@ -92,6 +96,7 @@ class Streamer(object):
         ------
         PescadorError
             If ``streamer`` is not a generator or an Iterable object.
+
         '''
 
         if not (inspect.isgeneratorfunction(streamer) or
@@ -149,6 +154,7 @@ class Streamer(object):
         See Also
         --------
         cycle : force an infinite stream.
+
         '''
         with StreamActivator(self):
             for n, obj in enumerate(self.stream_):
@@ -211,6 +217,7 @@ class Streamer(object):
         cycle
         tuples
         keras_tuples
+
         '''
         warn('`Streamer.tuples()` is deprecated in 1.1 '
              'This functionality is moved to `pescador.tuples` in 2.0. '
@@ -245,8 +252,8 @@ class Streamer(object):
 
         max_batches : None or int > 0
             .. warning:: This parameter name was deprecated in pescador 1.1
-            Use the `max_iter` parameter instead.
-            The `max_batches` parameter will be removed in pescador 2.0.
+                Use the `max_iter` parameter instead.
+                The `max_batches` parameter will be removed in pescador 2.0.
 
         Yields
         ------

--- a/pescador/maps.py
+++ b/pescador/maps.py
@@ -4,6 +4,13 @@
 Important note: map functions return a *generator*, not another streamer
 Streamer, so if you need it to behave like a Streamer, you have to wrap
 the function in a streamer again.
+
+.. autosummary::
+    :toctree: generated/
+
+    buffer_stream
+    tuples
+    keras_tuples
 '''
 import numpy as np
 import six

--- a/pescador/maps.py
+++ b/pescador/maps.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 '''Map functions perform operations on a stream.
 
-Important note: map functions return a *generator*, not another streamer
+Important note: map functions return a *generator*, not another
 Streamer, so if you need it to behave like a Streamer, you have to wrap
-the function in a streamer again.
+the function in a Streamer again.
 
 .. autosummary::
     :toctree: generated/

--- a/pescador/maps.py
+++ b/pescador/maps.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
-'''Map functions'''
+'''Map functions perform operations on a stream.
+
+Important note: map functions return a *generator*, not another streamer
+Streamer, so if you need it to behave like a Streamer, you have to wrap
+the function in a streamer again.
+'''
 import numpy as np
 import six
 
@@ -42,7 +47,8 @@ def buffer_stream(stream, buffer_size, partial=False,
 
     Raises
     ------
-    DataError if the stream contains items that are not data-like.
+    DataError
+        If the stream contains items that are not data-like.
     '''
 
     stream = util.rename_kw('generator', generator,
@@ -88,8 +94,10 @@ def tuples(stream, *keys):
 
     Raises
     ------
-    DataError if the stream contains items that are not data-like.
-    KeyError if a data object does not contain the requested key.
+    DataError
+        If the stream contains items that are not data-like.
+    KeyError
+        If a data object does not contain the requested key.
     """
     if not keys:
         raise PescadorError('Unable to generate tuples from '
@@ -132,7 +140,8 @@ def keras_tuples(stream, inputs=None, outputs=None):
 
     Raises
     ------
-    DataError if the stream contains items that are not data-like.
+    DataError
+        If the stream contains items that are not data-like.
     """
     flatten_inputs, flatten_outputs = False, False
     if inputs and isinstance(inputs, six.string_types):

--- a/pescador/mux.py
+++ b/pescador/mux.py
@@ -93,24 +93,24 @@ class Mux(core.Streamer):
 
         seed_pool : iterable of streamers
             .. warning:: This parameter name was deprecated in pescador 1.1
-            Use the `streamers` parameter instead.
-            The `seed_pool` parameter will be removed in pescador 2.0.
+                Use the `streamers` parameter instead.
+                The `seed_pool` parameter will be removed in pescador 2.0.
 
         lam : float > 0.0
             .. warning:: This parameter name was deprecated in pescador 1.1
-            Use the `rate` parameter instead.
-            The `lam` parameter will be removed in pescador 2.0.
+                Use the `rate` parameter instead.
+                The `lam` parameter will be removed in pescador 2.0.
 
         pool_weights : np.ndarray or None
             .. warning:: This parameter name was deprecated in pescador 1.1
-            Use the `weights` parameter instead.
-            The `pool_weights` parameter will be removed in pescador 2.0.
+                Use the `weights` parameter instead.
+                The `pool_weights` parameter will be removed in pescador 2.0.
 
         prune_empty_seeds : bool
             .. warning:: This parameter name was deprecated in pescador 1.1
-            Use the `prune_empty_streams` parameter instead.
-            The `prune_empty_seeds` parameter will be removed in
-            pescador 2.0.
+                Use the `prune_empty_streams` parameter instead.
+                The `prune_empty_seeds` parameter will be removed in
+                pescador 2.0.
         """
         streamers = rename_kw('seed_pool', seed_pool,
                               'streamers', streamers,


### PR DESCRIPTION
This PR (when complete) will complete documentation fixes for #83, #91. 

TODO:
- [x] Fix/update semantics to match the discussion / decisions in #75 
    - [x] samples vs batches
    - [x] iterators, iterables, and generators
- [x] BufferedStreamer => buffer_stream
- [x] buffer_batch => buffer_stream
- [x] New buffer_stream behavior (vstack, adding dimension)
- [x] Minor mux semantics changes
- [x] pescador.maps
- [ ] Changes from #91 for ZMQ