### PR TITLE
Tests for Mux statistics

### DIFF
--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -161,7 +161,6 @@ def test_mux_of_muxes_itered():
                         random_state=135)
     samples1 = mux1.iterate(max_iter=1000)
     count1 = collections.Counter(samples1)
-    print(count1)
     assert set('abcxyz') == set(count1.keys())
 
     n123 = pescador.Streamer('123')
@@ -171,7 +170,6 @@ def test_mux_of_muxes_itered():
                         random_state=246)
     samples2 = mux2.iterate(max_iter=1000)
     count2 = collections.Counter(samples2)
-    print(count2)
     assert set('123456') == set(count2.keys())
 
     # Note that (random_state=987, k=2) fails.
@@ -180,7 +178,6 @@ def test_mux_of_muxes_itered():
                         random_state=987)
     samples3 = mux3.iterate(max_iter=1000)
     count3 = collections.Counter(samples3)
-    print(count3)
     assert set('abcxyz123456') == set(count3.keys())
 
 
@@ -203,19 +200,20 @@ def test_mux_of_muxes_single():
                         prune_empty_streams=False)
     samples3 = list(mux3.iterate(max_iter=10000))
     count3 = collections.Counter(samples3)
-    print(samples3[:10], count3)
     assert set('abcxyz123456') == set(count3.keys())
 
 
 def test_critical_mux():
     # Check on Issue #80
     chars = 'abcde'
-    streamers = [pescador.Streamer(x * 5) for x in chars]
+    n_reps = 5
+    streamers = [pescador.Streamer(x * n_reps) for x in chars]
     mux = pescador.Mux(streamers, k=len(chars), rate=None,
-                       with_replacement=False, revive=True,
+                       with_replacement=False, revive=False,
                        prune_empty_streams=False, random_state=135)
-    samples = mux.iterate(max_iter=1000)
-    print(collections.Counter(samples))
+    samples = list(mux.iterate(max_iter=1000))
+    assert len(collections.Counter(samples)) == len(chars)
+    assert len(samples) == len(chars) * n_reps
 
 
 def _choice(vals):
@@ -251,7 +249,6 @@ def test_critical_mux_of_rate_limited_muxes():
     count = collections.Counter(samples)
     max_count, min_count = max(count.values()), min(count.values())
     assert (max_count - min_count) / max_count < 0.2
-    print(count)
     assert set('abcdefghijkl') == set(count.keys())
 
 
@@ -275,7 +272,7 @@ def test_sampled_mux_of_muxes():
     # And inspect the first mux
     samples1 = list(mux1(max_iter=6 * 10))
     count1 = collections.Counter(samples1)
-    print(count1)
+
     assert set(count1.keys()) == set('abcdef')
 
     # Build another set of streams
@@ -288,7 +285,6 @@ def test_sampled_mux_of_muxes():
     # And inspect the second mux
     samples2 = list(mux2(max_iter=6 * 10))
     count2 = collections.Counter(samples2)
-    print(count2)
     assert set(count2.keys()) == set('ghijkl')
 
     # Merge the muxes together.
@@ -296,7 +292,6 @@ def test_sampled_mux_of_muxes():
                         with_replacement=False, revive=False)
     samples3 = list(mux3.iterate(max_iter=10000))
     count3 = collections.Counter(samples3)
-    print(count3)
     assert set('abcdefghijkl') == set(count3.keys())
     max_count, min_count = max(count3.values()), min(count3.values())
     assert (max_count - min_count) / max_count < 0.2
@@ -315,31 +310,36 @@ def test_mux_inf_loop():
 
 
 def test_mux_stacked_uniform_convergence():
+    """This test is designed to check that boostrapped streams of data
+    (Streamer subsampling, rate limiting) cascaded through multiple
+    multiplexors converges in expectation to a flat, uniform sample of the
+    stream directly.
+    """
     ab = pescador.Streamer(_choice, 'ab')
     cd = pescador.Streamer(_choice, 'cd')
     ef = pescador.Streamer(_choice, 'ef')
-    mux1 = pescador.Mux([ab, cd, ef], k=2, rate=2,
-                        with_replacement=False, revive=True)
+    mux1 = pescador.Mux([ab, cd, ef], k=2, rate=2, with_replacement=False,
+                        revive=True, random_state=1357)
 
     gh = pescador.Streamer(_choice, 'gh')
     ij = pescador.Streamer(_choice, 'ij')
     kl = pescador.Streamer(_choice, 'kl')
 
-    mux2 = pescador.Mux([gh, ij, kl], k=2, rate=2,
-                        with_replacement=False, revive=True)
+    mux2 = pescador.Mux([gh, ij, kl], k=2, rate=2, with_replacement=False,
+                        revive=True, random_state=2468)
 
     stacked_mux = pescador.Mux([mux1, mux2], k=2, rate=None,
-                               with_replacement=False, revive=True)
+                               with_replacement=False, revive=True,
+                               random_state=159)
 
-    flat_mux = pescador.Mux([ab, cd, ef, gh, ij, kl], k=6, rate=None,
-                            with_replacement=False, revive=False)
+    flat_mux = pescador.Streamer(_choice, 'abcdefghijkl')
 
     max_iter = 50000
     samples1 = list(stacked_mux.iterate(max_iter=max_iter))
     samples2 = list(flat_mux.iterate(max_iter=max_iter))
     count1 = collections.Counter(samples1)
     count2 = collections.Counter(samples2)
-    print(count1, count2)
+
     assert set('abcdefghijkl') == set(count1.keys()) == set(count2.keys())
     c1, c2 = [list(c.values()) for c in (count1, count2)]
     np.testing.assert_almost_equal(

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -330,17 +330,17 @@ def test_mux_stacked_uniform_convergence():
 
     stacked_mux = pescador.Mux([mux1, mux2], k=2, rate=None,
                                with_replacement=False, revive=True,
-                               random_state=159)
-
-    flat_mux = pescador.Streamer(_choice, 'abcdefghijkl')
+                               random_state=12345)
 
     max_iter = 50000
-    samples1 = list(stacked_mux.iterate(max_iter=max_iter))
-    samples2 = list(flat_mux.iterate(max_iter=max_iter))
-    count1 = collections.Counter(samples1)
-    count2 = collections.Counter(samples2)
+    chars = 'abcdefghijkl'
+    samples = list(stacked_mux.iterate(max_iter=max_iter))
+    counter = collections.Counter(samples)
+    assert set(chars) == set(counter.keys())
 
-    assert set('abcdefghijkl') == set(count1.keys()) == set(count2.keys())
-    c1, c2 = [list(c.values()) for c in (count1, count2)]
-    np.testing.assert_almost_equal(
-        np.std(c1) / max_iter, np.std(c2) / max_iter, decimal=2)
+    counts = np.array(counter.values())
+    exp_count = float(max_iter / len(chars))
+    max_error = np.max(np.abs(counts - exp_count) / exp_count)
+
+    # Confirm the max difference is under 5% -- for these seeds, it's 2.2
+    assert max_error < 0.05

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -2,6 +2,7 @@ import pytest
 
 import collections
 import numpy as np
+import scipy.stats
 import random
 
 import pescador
@@ -338,7 +339,7 @@ def test_mux_stacked_uniform_convergence():
     counter = collections.Counter(samples)
     assert set(chars) == set(counter.keys())
 
-    counts = np.array(counter.values())
+    counts = np.asarray(list(counter.values()))
     exp_count = float(max_iter / len(chars))
     max_error = np.max(np.abs(counts - exp_count) / exp_count)
 


### PR DESCRIPTION
Adds a test that stacked bootstrapped streams are approximately uniform at large N.

Note: looking over Mux tests, we've accumulated pretty decent coverage the the sampling statistics of the Mux are behaving as advertised. I think some of the sanding and polish that's been thrown at pescador in the last several weeks has really ironed out some of the subtle kinks that were empirically felt / observed. This PR is more symbolic as a seal of approval that we're confident in our work.