### PR TITLE
Remove StreamActivator class

### DIFF
--- a/pescador/core.py
+++ b/pescador/core.py
@@ -7,21 +7,6 @@ import six
 from .exceptions import PescadorError
 
 
-class StreamActivator(object):
-    def __init__(self, streamer):
-        if not isinstance(streamer, Streamer):
-            raise PescadorError("`streamer` must be / inherit from Streamer")
-        self.streamer = streamer
-
-    def __enter__(self, *args, **kwargs):
-        self.streamer.activate()
-        return self
-
-    def __exit__(self, *exc):
-        self.streamer.deactivate()
-        return False
-
-
 class Streamer(object):
     '''A wrapper class for recycling iterables and generator functions, i.e.
     streamers.
@@ -107,6 +92,14 @@ class Streamer(object):
         self.kwargs = kwargs
         self.stream_ = None
 
+    def __enter__(self, *args, **kwargs):
+        self.activate()
+        return self
+
+    def __exit__(self, *exc):
+        self.deactivate()
+        return False
+
     @property
     def active(self):
         """Returns true if the stream is active
@@ -145,7 +138,8 @@ class Streamer(object):
         cycle : force an infinite stream.
 
         '''
-        with StreamActivator(self):
+        # Use self as context manager / calls __enter__() => activate()
+        with self:
             for n, obj in enumerate(self.stream_):
                 if max_iter is not None and n >= max_iter:
                     break

--- a/pescador/core.py
+++ b/pescador/core.py
@@ -93,11 +93,11 @@ class Streamer(object):
         self.stream_ = None
 
     def __enter__(self, *args, **kwargs):
-        self.activate()
+        self._activate()
         return self
 
     def __exit__(self, *exc):
-        self.deactivate()
+        self._deactivate()
         return False
 
     @property
@@ -107,7 +107,7 @@ class Streamer(object):
         """
         return self.stream_ is not None
 
-    def activate(self):
+    def _activate(self):
         """Activates the stream."""
         if six.callable(self.streamer):
             # If it's a function, create the stream.
@@ -117,7 +117,7 @@ class Streamer(object):
             # If it's iterable, use it directly.
             self.stream_ = iter(self.streamer)
 
-    def deactivate(self):
+    def _deactivate(self):
         self.stream_ = None
 
     def iterate(self, max_iter=None):
@@ -138,7 +138,7 @@ class Streamer(object):
         cycle : force an infinite stream.
 
         '''
-        # Use self as context manager / calls __enter__() => activate()
+        # Use self as context manager / calls __enter__() => _activate()
         with self:
             for n, obj in enumerate(self.stream_):
                 if max_iter is not None and n >= max_iter:

--- a/pescador/mux.py
+++ b/pescador/mux.py
@@ -214,7 +214,8 @@ class Mux(core.Streamer):
         self.weight_norm_ = None
 
     def iterate(self, max_iter=None):
-        with core.StreamActivator(self):
+        # Calls Streamer's __enter__, which calls activate()
+        with self:
 
             # Main sampling loop
             n = 0
@@ -403,7 +404,8 @@ class BaseMux(core.Streamer):
         if max_iter is None:
             max_iter = np.inf
 
-        with core.StreamActivator(self):
+        # Calls Streamer's __enter__, which calls activate()
+        with self:
             # Main sampling loop
             n = 0
 

--- a/pescador/mux.py
+++ b/pescador/mux.py
@@ -153,7 +153,7 @@ class Mux(core.Streamer):
         self.prune_empty_streams = prune_empty_streams
         self.revive = revive
 
-        self.deactivate()
+        self._deactivate()
 
         if random_state is None:
             self.rng = np.random
@@ -182,7 +182,7 @@ class Mux(core.Streamer):
 
         self.weights /= np.sum(self.weights)
 
-    def activate(self):
+    def _activate(self):
         """Activates a number of streams"""
         self.distribution_ = 1. / self.n_streams * np.ones(self.n_streams)
         self.valid_streams_ = np.ones(self.n_streams, dtype=bool)
@@ -206,7 +206,7 @@ class Mux(core.Streamer):
 
         self.weight_norm_ = np.sum(self.stream_weights_)
 
-    def deactivate(self):
+    def _deactivate(self):
         self.streams_ = None
         self.stream_weights_ = None
         self.stream_counts_ = None
@@ -214,7 +214,7 @@ class Mux(core.Streamer):
         self.weight_norm_ = None
 
     def iterate(self, max_iter=None):
-        # Calls Streamer's __enter__, which calls activate()
+        # Calls Streamer's __enter__, which calls _activate()
         with self:
 
             # Main sampling loop
@@ -292,14 +292,6 @@ class Mux(core.Streamer):
         idx : int, [0:n_streams - 1]
             The stream index to replace
         '''
-        if len(self.streamers) != len(self.weights):
-            raise PescadorError('`streamers` must have the same '
-                                'length as `weights`')
-
-        if len(self.streamers) != len(self.distribution_):
-            raise PescadorError('`streamers` must have the same '
-                                'length as `distribution`')
-
         # instantiate
         if self.rate is not None:
             n_stream = 1 + self.rng.poisson(lam=self.rate)
@@ -362,7 +354,7 @@ class BaseMux(core.Streamer):
             raise PescadorError('Invalid random_state={}'.format(random_state))
 
         # Clear state and reset actiave/deactivate params.
-        self.deactivate()
+        self._deactivate()
 
     @property
     def n_streams(self):
@@ -373,7 +365,7 @@ class BaseMux(core.Streamer):
         """
         return len(self.streamers)
 
-    def activate(self):
+    def _activate(self):
         """Activates the mux as a streamer, choosing which substreams to
         select as active.
 
@@ -393,7 +385,7 @@ class BaseMux(core.Streamer):
         """
         raise NotImplementedError()
 
-    def deactivate(self):
+    def _deactivate(self):
         """Reset the Mux state."""
         pass
 
@@ -583,7 +575,7 @@ class PoissonMux(BaseMux):
 
         self.weights /= np.sum(self.weights)
 
-    def activate(self):
+    def _activate(self):
         # These do not depend on the number of streams, k
         self.distribution_ = 1. / self.n_streams * np.ones(self.n_streams)
         self.valid_streams_ = np.ones(self.n_streams, dtype=bool)
@@ -615,7 +607,7 @@ class PoissonMux(BaseMux):
 
         self.weight_norm_ = np.sum(self.stream_weights_)
 
-    def deactivate(self):
+    def _deactivate(self):
         self.distribution_ = np.zeros(self.n_streams)
         self.valid_streams_ = np.zeros(self.n_streams)
 
@@ -781,7 +773,7 @@ class ShuffledMux(BaseMux):
 
         self.weights /= np.sum(self.weights)
 
-    def activate(self):
+    def _activate(self):
         """ShuffledMux's activate is similar to PoissonMux,
         but there is no 'k_active', since all the streams are always available.
         """
@@ -917,10 +909,10 @@ class RoundRobinMux(BaseMux):
         if not self.n_streams:
             raise PescadorError('Cannot mux an empty collection')
 
-    def activate(self):
+    def _activate(self):
         self._setup_streams(False)
 
-    def deactivate(self):
+    def _deactivate(self):
         self.active_index_ = None
         self.streams_ = None
         self.stream_idxs_ = None
@@ -1086,7 +1078,7 @@ class ChainMux(BaseMux):
 
         self.mode = mode
 
-    def activate(self):
+    def _activate(self):
         # Use a streamer to iterate over the input streamers.
         # This allows the streamers to be an iterable, and also easily
         #  be restarted.
@@ -1104,7 +1096,7 @@ class ChainMux(BaseMux):
         # Setup a new streamer at this index.
         self._new_stream()
 
-    def deactivate(self):
+    def _deactivate(self):
         self.chain_streamer_ = None
         self.chain_generator_ = None
         self.streams_ = None

--- a/pescador/mux.py
+++ b/pescador/mux.py
@@ -793,7 +793,7 @@ class ShuffledMux(BaseMux):
 
         self.weight_norm_ = np.sum(self.stream_weights_)
 
-    def deactivate(self):
+    def _deactivate(self):
         self.streams_ = None
         self.stream_weights_ = None
         self.stream_counts_ = None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,11 +10,6 @@ import pescador.core
 import test_utils as T
 
 
-def test_StreamActivator():
-    with pytest.raises(pescador.core.PescadorError):
-        pescador.core.StreamActivator(range)
-
-
 def test_streamer_iterable():
     n_items = 10
     expected = list(range(n_items))

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -138,6 +138,22 @@ def test_mux_bad_weights(mux_class):
         mux_class(streamers, weights=np.zeros(5))
 
 
+class TestPoissonMux:
+    @pytest.mark.parametrize(
+        'mode', ['with_replacement', 'single_active', 'exhaustive',
+                 pytest.mark.xfail('foo', raises=pescador.PescadorError),
+                 pytest.mark.xfail(None, raises=pescador.PescadorError)])
+    @pytest.mark.parametrize('n_samples', [10])
+    def test_valid_modes(self, mode, n_samples):
+        """Simply tests the modes to make sure they work."""
+        streamers = [pescador.Streamer(T.infinite_generator)
+                     for _ in range(4)]
+
+        mux = pescador.mux.PoissonMux(streamers, 1, rate=10, mode=mode)
+        output = list(mux.iterate(n_samples))
+        assert len(output) == n_samples
+
+
 @pytest.mark.parametrize('mux_class', [
     pescador.mux.Mux, pescador.mux.PoissonMux],
     ids=["DeprecatedMux",


### PR DESCRIPTION
Implements #108 - Removes separate `StreamActivator` class, and converts `Streamer`  to using itself as a Context Manager instead. (for both `Streamer` and `BaseMux`).