### PR TITLE
Fix Copy Streamers Bug

### DIFF
--- a/pescador/core.py
+++ b/pescador/core.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Core classes"""
 import collections
+import copy
 import inspect
 import six
 
@@ -92,9 +93,13 @@ class Streamer(object):
         self.kwargs = kwargs
         self.stream_ = None
 
+    def copy(self):
+        return copy.deepcopy(self)
+
     def __enter__(self, *args, **kwargs):
-        self._activate()
-        return self
+        streamer_copy = self.copy()
+        streamer_copy._activate()
+        return streamer_copy
 
     def __exit__(self, *exc):
         self._deactivate()
@@ -139,8 +144,8 @@ class Streamer(object):
 
         '''
         # Use self as context manager / calls __enter__() => _activate()
-        with self:
-            for n, obj in enumerate(self.stream_):
+        with self as active_streamer:
+            for n, obj in enumerate(active_streamer.stream_):
                 if max_iter is not None and n >= max_iter:
                     break
                 yield obj

--- a/pescador/core.py
+++ b/pescador/core.py
@@ -90,6 +90,7 @@ class Streamer(object):
 
         # The iterable or callable to stream from
         self.streamer = streamer
+
         # Args and kwargs are passed to an instantiated function
         self.args = args
         self.kwargs = kwargs
@@ -118,8 +119,8 @@ class Streamer(object):
         return copy_result
 
     def __enter__(self, *args, **kwargs):
-        # If this is the base / original streamer, create a copy and return
-        # it
+        # If this is the base / original streamer,
+        #  create a copy and return it
         if not self.is_activated_copy:
             streamer_copy = copy.deepcopy(self)
             streamer_copy._activate()
@@ -127,7 +128,7 @@ class Streamer(object):
             # Increment the count of active streams.
             self.active_count_ += 1
 
-        # However, if this is an activated streamer, then it is a copy,
+        # However, if this is an "activated" streamer, then it is a copy,
         #  so just return self.
         else:
             streamer_copy = self
@@ -136,8 +137,6 @@ class Streamer(object):
 
     def __exit__(self, *exc):
         if not self.is_activated_copy:
-
-            self._deactivate()
 
             # Decrement the count of active streams.
             self.active_count_ -= 1
@@ -171,9 +170,6 @@ class Streamer(object):
         else:
             # If it's iterable, use it directly.
             self.stream_ = iter(self.streamer)
-
-    def _deactivate(self):
-        self.stream_ = None
 
     def iterate(self, max_iter=None):
         '''Instantiate an iterator.

--- a/pescador/core.py
+++ b/pescador/core.py
@@ -102,14 +102,26 @@ class Streamer(object):
         # in the copy created.
         self.stream_ = None
 
-    def copy(self):
-        return copy.deepcopy(self)
+    def __copy__(self):
+        cls = self.__class__
+        copy_result = cls.__new__(cls)
+        copy_result.__dict__.update(self.__dict__)
+        return copy_result
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        copy_result = cls.__new__(cls)
+        memo[id(self)] = copy_result
+        for k, v in six.iteritems(self.__dict__):
+            setattr(copy_result, k, copy.deepcopy(v, memo))
+
+        return copy_result
 
     def __enter__(self, *args, **kwargs):
         # If this is the base / original streamer, create a copy and return
         # it
         if not self.is_activated_copy:
-            streamer_copy = self.copy()
+            streamer_copy = copy.deepcopy(self)
             streamer_copy._activate()
 
             # Increment the count of active streams.

--- a/pescador/mux.py
+++ b/pescador/mux.py
@@ -180,6 +180,11 @@ class Mux(core.Streamer):
 
         self.weights /= np.sum(self.weights)
 
+        # When a stream is activated, a copy of this mux is made via
+        # the core.Streamer context manager.
+        # The number of copies is tracked with active_count_.
+        self.active_count_ = 0
+
     def _activate(self):
         """Activates a number of streams"""
         self.distribution_ = 1. / self.n_streams * np.ones(self.n_streams)
@@ -360,6 +365,11 @@ class BaseMux(core.Streamer):
 
         # Clear state and reset actiave/deactivate params.
         self._deactivate()
+
+        # When a stream is activated, a copy of this mux is made via
+        # the core.Streamer context manager.
+        # The number of copies is tracked with active_count_.
+        self.active_count_ = 0
 
     @property
     def n_streams(self):
@@ -1078,8 +1088,14 @@ class ChainMux(BaseMux):
             If None, the random number generator is the RandomState instance
             used by np.random.
         """
+        # if inspect.isgeneratorfunction(streamers):
+        #     streamers = core.Streamer(streamers)
+
         super(ChainMux, self).__init__(
             streamers, random_state=random_state)
+
+        if mode not in ["exhaustive", "cycle"]:
+            raise PescadorError("Invalid ChainMux mode '{}'".format(mode))
 
         self.mode = mode
 

--- a/pescador/mux.py
+++ b/pescador/mux.py
@@ -189,7 +189,11 @@ class Mux(core.Streamer):
         self.active_count_ = 0
 
     def __deepcopy__(self, memo):
-        "This override is required to handle copying the random_state"
+        """This override is required to handle copying the random_state:
+        when using `random_state=None`, the global state is used;
+        modules are not 'deepcopy-able', so we have to make a special case for
+        it.
+        """
         cls = self.__class__
         copy_result = cls.__new__(cls)
         memo[id(self)] = copy_result
@@ -401,7 +405,11 @@ class BaseMux(core.Streamer):
         self.active_count_ = 0
 
     def __deepcopy__(self, memo):
-        "This override is required to handle copying the random_state"
+        """This override is required to handle copying the random_state:
+        when using `random_state=None`, the global state is used;
+        modules are not 'deepcopy-able', so we have to make a special case for
+        it.
+        """
         cls = self.__class__
         copy_result = cls.__new__(cls)
         memo[id(self)] = copy_result

--- a/pescador/mux.py
+++ b/pescador/mux.py
@@ -185,6 +185,13 @@ class Mux(core.Streamer):
         # The number of copies is tracked with active_count_.
         self.active_count_ = 0
 
+    @property
+    def is_activated_copy(self):
+        """is_active is true if this object is a copy of the original Streamer
+        *and* has been activated.
+        """
+        return self.streams_ is not None
+
     def _activate(self):
         """Activates a number of streams"""
         self.distribution_ = 1. / self.n_streams * np.ones(self.n_streams)
@@ -370,6 +377,13 @@ class BaseMux(core.Streamer):
         # the core.Streamer context manager.
         # The number of copies is tracked with active_count_.
         self.active_count_ = 0
+
+    @property
+    def is_activated_copy(self):
+        """is_active is true if this object is a copy of the original Streamer
+        *and* has been activated.
+        """
+        return self.streams_ is not None
 
     @property
     def n_streams(self):
@@ -808,7 +822,7 @@ class ShuffledMux(BaseMux):
 
         self.weight_norm_ = np.sum(self.stream_weights_)
 
-    def deactivate(self):
+    def _deactivate(self):
         self.streams_ = None
         self.stream_weights_ = None
         self.stream_counts_ = None

--- a/pescador/mux.py
+++ b/pescador/mux.py
@@ -154,7 +154,7 @@ class Mux(core.Streamer):
         self.prune_empty_streams = prune_empty_streams
         self.revive = revive
 
-        self._deactivate()
+        self._reset()
 
         if random_state is None:
             self.rng = np.random
@@ -208,6 +208,13 @@ class Mux(core.Streamer):
 
         return copy_result
 
+    def _reset(self):
+        self.streams_ = None
+        self.stream_weights_ = None
+        self.stream_counts_ = None
+        self.stream_idxs_ = None
+        self.weight_norm_ = None
+
     @property
     def is_activated_copy(self):
         """is_active is true if this object is a copy of the original Streamer
@@ -238,13 +245,6 @@ class Mux(core.Streamer):
                 self._new_stream(self.stream_idxs_[idx]))
 
         self.weight_norm_ = np.sum(self.stream_weights_)
-
-    def _deactivate(self):
-        self.streams_ = None
-        self.stream_weights_ = None
-        self.stream_counts_ = None
-        self.stream_idxs_ = None
-        self.weight_norm_ = None
 
     def iterate(self, max_iter=None):
         # Calls Streamer's __enter__, which calls _activate()
@@ -396,8 +396,8 @@ class BaseMux(core.Streamer):
         else:
             raise PescadorError('Invalid random_state={}'.format(random_state))
 
-        # Clear state and reset actiave/deactivate params.
-        self._deactivate()
+        # Clear state and reset activate params.
+        self._reset()
 
         # When a stream is activated, a copy of this mux is made via
         # the core.Streamer context manager.
@@ -460,7 +460,7 @@ class BaseMux(core.Streamer):
         """
         raise NotImplementedError()
 
-    def _deactivate(self):
+    def _reset(self):
         """Reset the Mux state."""
         pass
 
@@ -682,7 +682,7 @@ class PoissonMux(BaseMux):
 
         self.weight_norm_ = np.sum(self.stream_weights_)
 
-    def _deactivate(self):
+    def _reset(self):
         self.distribution_ = np.zeros(self.n_streams)
         self.valid_streams_ = np.zeros(self.n_streams)
 
@@ -868,7 +868,7 @@ class ShuffledMux(BaseMux):
 
         self.weight_norm_ = np.sum(self.stream_weights_)
 
-    def _deactivate(self):
+    def _reset(self):
         self.streams_ = None
         self.stream_weights_ = None
         self.stream_counts_ = None
@@ -987,7 +987,7 @@ class RoundRobinMux(BaseMux):
     def _activate(self):
         self._setup_streams(False)
 
-    def _deactivate(self):
+    def _reset(self):
         self.active_index_ = None
         self.streams_ = None
         self.stream_idxs_ = None
@@ -1177,7 +1177,7 @@ class ChainMux(BaseMux):
         # Setup a new streamer at this index.
         self._new_stream()
 
-    def _deactivate(self):
+    def _reset(self):
         self.chain_streamer_ = None
         self.chain_generator_ = None
         self.streams_ = None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -175,6 +175,18 @@ def test_streamer_context_copy():
         assert active_stream.args == streamer.args
         assert active_stream.kwargs == streamer.kwargs
 
+        assert active_stream.is_activated_copy is True
+
+        # Now, we should be able to iterate on active_stream without it
+        # causing another copy.
+        with active_stream as test_stream:
+            assert active_stream is test_stream
+            assert streamer.active == 1
+
+        # Exhaust the stream once.
+        query = list(active_stream)
+        assert stream_len == len(query)
+
     assert streamer.active == 0
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -241,6 +241,7 @@ def test_streamer_context_multiple_copies():
     # Active the streamer multiple times with iterate
     gen1 = streamer.iterate(5)
     gen2 = streamer.iterate(7)
+    assert id(gen1) != id(gen2)
 
     # No streamers should be active until we actually start the generators
     assert streamer.active == 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -143,3 +143,29 @@ def test_streamer_bad_function():
 
     with pytest.raises(pescador.core.PescadorError):
         pescador.Streamer(__fail)
+
+
+def test_streamer_context_copy():
+    """Check that the streamer produced by __enter__/activate
+    is a *different* streamer than the original.
+
+    Note: Do not use the streamer in this way in your code! You
+    can't actually extract samples from the streamer using the context
+    manager externally.
+    """
+    stream_len = 10
+    streamer = pescador.core.Streamer(T.finite_generator, stream_len)
+    assert streamer.stream_ is None
+
+    with streamer as active_stream:
+        assert isinstance(active_stream, pescador.core.Streamer)
+        # Check that the objects are not the same
+        assert active_stream is not streamer
+
+        assert streamer.stream_ is None
+        # The active stream should have been activated.
+        assert active_stream.stream_ is not None
+        assert active_stream.streamer == streamer.streamer
+        assert active_stream.streamer is streamer.streamer
+        assert active_stream.args == streamer.args
+        assert active_stream.kwargs == streamer.kwargs

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -48,7 +48,9 @@ def test_mux_single_finite(mux_class):
 
     mux = mux_class([stream])
     estimate = list(mux)
-    assert reference == estimate
+    assert len(reference) == len(estimate)
+    for i, d in enumerate(estimate):
+        assert d.items() == estimate[i].items()
 
 
 @pytest.mark.parametrize('mux_class', [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,11 +54,11 @@ def md_generator(dimension, n, size=2, items='X'):
                for j, item in enumerate(items)}
 
 
-def infinite_generator(size=2):
+def infinite_generator(size=2, offset=0):
 
     i = 0
     while True:
-        yield {'X': np.tile(np.array([[i]]), (size, 1))}
+        yield {'X': np.tile(np.array([[i]]), (size, 1)) + offset}
         i = i + 1
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,18 @@ def _eq_lists(b1, b2):
         assert np.allclose(i, j)
 
 
+def _eq_list_of_dicts(b1, b2):
+    results = []
+    results.append(len(b1) == len(b2))
+
+    if results[-1]:
+        for i in range(len(b1)):
+            for k in six.iterkeys(b1[i]):
+                results.append(np.allclose(b1[i][k], b2[i][k]))
+
+    return np.all(results)
+
+
 def finite_generator(n, size=2, lag=None):
 
     for i in range(n):


### PR DESCRIPTION
Implements #112.

When activated, streamers now return a copy of themselves. This is necessary in order to allow a single streamer to be used multiple times. The most obvious use case here (which did not work before!) was the `PoissonMux` in `with_replacement` mode, where a single stream should be able to be used multiple times.

In order to achieve this, each streamer (both `pescador.mux.BaseMux` derived classes and `pescador.Streamer`) operates on a new, deep-copy of itself each time it is activated with `.iterate()`.

Includes various updates to tests to test for this behavior.