### PR TITLE
fixes #116 - cycle now respects max_iter

### DIFF
--- a/pescador/core.py
+++ b/pescador/core.py
@@ -220,7 +220,7 @@ class Streamer(object):
 
         count = 0
         while True:
-            for obj in self:
+            for obj in self.iterate():
                 count += 1
                 if max_iter is not None and count > max_iter:
                     return

--- a/pescador/core.py
+++ b/pescador/core.py
@@ -55,6 +55,11 @@ class Streamer(object):
     >>> for i in stream.cycle():
     ...     print(i)  # Displays 0, 1, 2, 3, 4, 0, 1, 2, ...
 
+    Or finitely many examples, restarting the generator as needed
+
+    >>> for i in stream.cycle(max_iter=7):
+    ...     print(i)  # Displays 0, 1, 2, 3, 4, 0, 1
+
 
     An alternate interface for the same:
 
@@ -196,19 +201,29 @@ class Streamer(object):
                     break
                 yield obj
 
-    def cycle(self):
+    def cycle(self, max_iter=None):
         '''Iterate from the streamer infinitely.
 
         This function will force an infinite stream, restarting
         the streamer even if a StopIteration is raised.
+
+        Parameters
+        ----------
+        max_iter : None or int > 0
+            Maximum number of iterations to yield.
+            If `None`, iterate indefinitely.
 
         Yields
         ------
         obj : Objects yielded by the streamer provided on init.
         '''
 
+        count = 0
         while True:
             for obj in self:
+                count += 1
+                if max_iter is not None and count > max_iter:
+                    return
                 yield obj
 
     def __call__(self, max_iter=None, cycle=False):
@@ -235,7 +250,7 @@ class Streamer(object):
         cycle
         '''
         if cycle:
-            gen = self.cycle()
+            gen = self.cycle(max_iter=max_iter)
         else:
             gen = self.iterate(max_iter=max_iter)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -137,6 +137,18 @@ def test_streamer_cycle(generate):
     assert (len(data_results) == count_max and all(data_results))
 
 
+@pytest.mark.parametrize('max_iter', [3, 10])
+def test_streamer_cycle_maxiter(max_iter):
+
+    s = pescador.Streamer(T.finite_generator, 6)
+
+    r1 = list(s.cycle(max_iter=max_iter))
+    assert len(r1) == max_iter
+
+    r2 = list(s(max_iter=max_iter, cycle=True))
+    assert len(r2) == max_iter
+
+
 def test_streamer_bad_function():
 
     def __fail():


### PR DESCRIPTION
This PR fixes #116 so that `max_iter` is respected when cycling a Streamer.  This is primarily useful when you want to produce exactly `max_iter` steps, even if the underlying generator stops at `n < max_iter`.

It is also useful for getting some finnicky corner-case behaviors in `PoissonMux` to behave appropriately, eg, epoch sampling.

AFAIK this is ready for CR.