### PR TITLE
fixes #119 - renames PoissonMux to StochasticMux

### DIFF
--- a/docs/example2.rst
+++ b/docs/example2.rst
@@ -7,8 +7,8 @@ We will assume a working understanding of the simple example in the previous sec
 Stream re-use and multiplexing
 ==============================
 
-The `Mux` streamer provides a powerful interface for randomly interleaving samples from multiple input streams.
-`Mux` can also dynamically activate and deactivate individual `Streamers`, which allows it to operate on a bounded subset of streams at any given time.
+The `StochasticMux` streamer provides a powerful interface for randomly interleaving samples from multiple input streams.
+`StochasticMux` can also dynamically activate and deactivate individual `Streamers`, which allows it to operate on a bounded subset of streams at any given time.
 
 As a concrete example, we can simulate a mixture of noisy streams with differing variances.
 
@@ -24,7 +24,7 @@ As a concrete example, we can simulate a mixture of noisy streams with differing
     from sklearn.model_selection import ShuffleSplit
     from sklearn.metrics import accuracy_score
 
-    from pescador import Streamer, Mux
+    from pescador import Streamer, StochasticMux
 
     def noisy_samples(X, Y, sigma=1.0):
         '''Copied over from the previous example'''
@@ -54,9 +54,9 @@ As a concrete example, we can simulate a mixture of noisy streams with differing
                    for sigma in [0, 0.5, 1.0, 2.0, 4.0]]
 
         # Build a mux stream, keeping 3 streams alive at once
-        mux_stream = Mux(streams,
-                         k=3,    # Keep 3 streams alive at once
-                         rate=64) # Use a poisson rate of 64
+        mux_stream = StochasticMux(streams,
+                                   3,        # Keep 3 streams alive at once
+                                   rate=64)  # Use a poisson rate of 64
 
         # Fit the model to the stream, use at most 5000 samples
         for sample in mux_stream(max_iter=5000):
@@ -67,15 +67,15 @@ As a concrete example, we can simulate a mixture of noisy streams with differing
         print('Test accuracy: {:.3f}'.format(accuracy_score(Y[test], Ypred)))
 
 
-In the above example, each `Streamer` in `streams` can make infinitely many samples. The `rate=64` argument to `Mux` says that each stream should produce some `n` samples, where `n` is sampled from a Poisson distribution of rate `rate`.
+In the above example, each `Streamer` in `streams` can make infinitely many samples. The `rate=64` argument to
+`StochasticMux` says that each stream should produce some `n` samples, where `n` is sampled from a Poisson distribution of rate `rate`.
 When a stream exceeds its bound, it is deactivated, and a new streamer is activated to fill its place.
 
-Setting `rate=None` disables the random stream bounding, and `mux()` simply runs each active stream until exhaustion.
+Setting `rate=None` disables the random stream bounding, and simply runs each active stream until exhaustion.
 
-The `Mux` streamer can sampled with or without replacement from its input streams, according to the `with_replacement` option.
-Setting this parameter to `False` means that each stream can be active at most once.
+The `StochasticMux` streamer can sampled with or without replacement from its input streams, according to the `mode` option.
+Setting this parameter to `single_active` means that each stream can be active at most once.
 
 Streams can also be sampled with non-uniform weighting by specifying a vector of `weights`.
 
-Finally, exhausted streams can be removed by setting `prune_empty_streams` to `True`.
-If `False`, then exhausted streams may be reactivated at any time.
+Finally, exhausted streams can be removed by setting `mode='exhaustive'`.

--- a/examples/mux/epoch.py
+++ b/examples/mux/epoch.py
@@ -17,7 +17,7 @@ depending on the exact sampling properties you have in mind.
   the model.
 
 - If you want random presentation order, but want to ensure that
-  all data is touched once per epoch, then the `PoissonMux` can be
+  all data is touched once per epoch, then the `StochasticMux` can be
   used in `cycle` mode to restart all streamers once they've been
   exhausted.
   
@@ -63,9 +63,9 @@ def data_gen(filename, m):
 streams = [pescador.Streamer(data_gen, fn, M) for fn in files]
 
 ###############################
-# Epochs with PoissonMux
+# Epochs with StochasticMux
 ###############################
-# The `PoissonMux` has three modes of operation, which control
+# The `StochasticMux` has three modes of operation, which control
 # how its input streams are activated and replaced:
 # - `mode='with_replacement'` allows each streamer to be activated
 #   multiple times, even simultaneously.
@@ -86,7 +86,7 @@ k = 100  # or however many streamers you want simultaneously active
 
 # We'll use `rate=None` here so that the number of samples per stream is
 # determined by the streamer (`M`) and not the mux.
-mux = pescador.PoissonMux(streams, k, rate=None, mode='exhaustive')
+mux = pescador.StochasticMux(streams, k, rate=None, mode='exhaustive')
 
 epoch_stream = mux(cycle=True)
 

--- a/examples/mux/shuffle.py
+++ b/examples/mux/shuffle.py
@@ -15,7 +15,7 @@ Perhaps the total number of images is larger than fits comfortably
 in memory, but you still want to produce a stream of training data
 with uniform class presentation.
 
-To solve this in pescador, we will first create a `PoissonMux` for each
+To solve this in pescador, we will first create a `StochasticMux` for each
 sub-population (e.g., one for cars, one for boats, etc.), which will
 maintain a small active set.
 We will then combine those sub-population muxen using `ShuffledMux` to
@@ -51,11 +51,11 @@ pop2 = [pescador.Streamer(letter, c) for c in 'abcdefghijklmnopqrstuvwxyz']
 # We'll sample population 1 with 3 streamers active at any time.
 # Each streamer will generate, on average, 5 samples before being
 # replaced.
-mux1 = pescador.PoissonMux(pop1, 3, 5)
+mux1 = pescador.StochasticMux(pop1, 3, 5)
 
 # Let's have 5 active streamers for population 2, and replace
 # them after 2 examples on average.
-mux2 = pescador.PoissonMux(pop2, 5, 2)
+mux2 = pescador.StochasticMux(pop2, 5, 2)
 
 ####################
 # Mux composition

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -30,13 +30,13 @@ def _choice(vals, seed=11111):
 
 @pytest.mark.parametrize('mux_class', [
     functools.partial(pescador.mux.Mux, k=1, with_replacement=False),
-    functools.partial(pescador.mux.PoissonMux, n_active=1, rate=None,
+    functools.partial(pescador.mux.StochasticMux, n_active=1, rate=None,
                       mode="exhaustive"),
     pescador.mux.RoundRobinMux,
     pescador.mux.ChainMux,
 ],
     ids=["DeprecatedMux",
-         "PoissonMux-exhaustive",
+         "StochasticMux-exhaustive",
          "RoundRobin",
          "ChainMux",
          ])
@@ -55,17 +55,17 @@ def test_mux_single_finite(mux_class):
 
 @pytest.mark.parametrize('mux_class', [
     functools.partial(pescador.mux.Mux, k=1, with_replacement=True),
-    functools.partial(pescador.mux.PoissonMux, n_active=1, rate=None,
+    functools.partial(pescador.mux.StochasticMux, n_active=1, rate=None,
                       mode="with_replacement"),
-    functools.partial(pescador.mux.PoissonMux, n_active=1, rate=None,
+    functools.partial(pescador.mux.StochasticMux, n_active=1, rate=None,
                       mode="single_active"),
     pescador.mux.ShuffledMux,
     functools.partial(pescador.mux.RoundRobinMux, mode="cycle"),
     functools.partial(pescador.mux.ChainMux, mode="cycle"),
 ],
     ids=["DeprecatedMux",
-         "PoissonMux-with_replacement",
-         "PoissonMux-single_active",
+         "StochasticMux-with_replacement",
+         "StochasticMux-single_active",
          "ShuffledMux",
          "RoundRobinMux",
          "ChainMux-cycle"
@@ -90,7 +90,7 @@ def test_mux_single_infinite(mux_class):
 
 @pytest.mark.parametrize('mux_class', [
     functools.partial(pescador.mux.Mux, k=1),
-    functools.partial(pescador.mux.PoissonMux, n_active=1, rate=256),
+    functools.partial(pescador.mux.StochasticMux, n_active=1, rate=256),
     pescador.mux.ShuffledMux,
     pescador.mux.RoundRobinMux,
     pytest.mark.xfail(pescador.mux.ChainMux,
@@ -99,7 +99,7 @@ def test_mux_single_infinite(mux_class):
                       strict=True),
 ],
     ids=["DeprecatedMux",
-         "PoissonMux-exhaustive",
+         "StochasticMux-exhaustive",
          "ShuffledMux",
          "RoundRobinMux",
          "ChainMux"
@@ -112,11 +112,11 @@ def test_mux_empty(mux_class):
 
 @pytest.mark.parametrize('mux_class', [
     functools.partial(pescador.mux.Mux, k=None),
-    functools.partial(pescador.mux.PoissonMux, n_active=None, rate=256),
+    functools.partial(pescador.mux.StochasticMux, n_active=None, rate=256),
     pescador.mux.ShuffledMux,
 ],
     ids=["DeprecatedMux",
-         "PoissonMux",
+         "StochasticMux",
          "ShuffledMux",
          ])
 def test_mux_bad_streamers(mux_class):
@@ -130,11 +130,11 @@ def test_mux_bad_streamers(mux_class):
 
 @pytest.mark.parametrize('mux_class', [
     functools.partial(pescador.mux.Mux, k=None),
-    functools.partial(pescador.mux.PoissonMux, n_active=None, rate=256),
+    functools.partial(pescador.mux.StochasticMux, n_active=None, rate=256),
     pescador.mux.ShuffledMux,
 ],
     ids=["DeprecatedMux",
-         "PoissonMux",
+         "StochasticMux",
          "ShuffledMux",
          ])
 def test_mux_bad_weights(mux_class):
@@ -162,7 +162,7 @@ def test_mux_of_mux():
     base1 = pescador.mux.ShuffledMux([a, b], random_state=1)
     base2 = pescador.mux.ShuffledMux([c, d, e], random_state=10)
     base3 = pescador.mux.ShuffledMux([f, g, h], random_state=100)
-    train_mux = pescador.mux.PoissonMux(
+    train_mux = pescador.mux.StochasticMux(
         [base1, base2, base3], n_active=2, rate=3, mode="with_replacement",
         random_state=123)
 
@@ -176,7 +176,7 @@ class TestCopyMux:
     @pytest.mark.parametrize('mux_class', [
         functools.partial(pescador.mux.Mux, k=10, rate=3,
                           with_replacement=True),
-        functools.partial(pescador.mux.PoissonMux, n_active=10, rate=3,
+        functools.partial(pescador.mux.StochasticMux, n_active=10, rate=3,
                           mode='with_replacement'),
         pescador.mux.ShuffledMux,
         pescador.mux.RoundRobinMux,
@@ -184,7 +184,7 @@ class TestCopyMux:
     ],
         ids=[
         "DeprecatedMux",
-        "PoissonMux",
+        "StochasticMux",
         "ShuffledMux",
         "RoundRobinMux",
         "ChainMux"
@@ -226,7 +226,7 @@ class TestCopyMux:
             assert T._eq_list_of_dicts(sample1, sample2)
 
 
-class TestPoissonMux:
+class TestStochasticMux:
     @pytest.mark.parametrize(
         'mode', ['with_replacement', 'single_active', 'exhaustive',
                  pytest.mark.xfail('foo', raises=pescador.PescadorError),
@@ -237,7 +237,7 @@ class TestPoissonMux:
         streamers = [pescador.Streamer(T.infinite_generator)
                      for _ in range(4)]
 
-        mux = pescador.mux.PoissonMux(streamers, 1, rate=10, mode=mode)
+        mux = pescador.mux.StochasticMux(streamers, 1, rate=10, mode=mode)
         output = list(mux.iterate(n_samples))
         assert len(output) == n_samples
 
@@ -247,7 +247,7 @@ class TestPoissonMux:
         ab = pescador.Streamer('ab')
         cde = pescador.Streamer('cde')
         fghi = pescador.Streamer('fghi')
-        mux = pescador.mux.PoissonMux([ab, cde, fghi], n_active=5, rate=2)
+        mux = pescador.mux.StochasticMux([ab, cde, fghi], n_active=5, rate=2)
 
         gen1 = mux.iterate(6)
         gen2 = mux.iterate(8)
@@ -274,10 +274,10 @@ class TestPoissonMux:
 
 @pytest.mark.parametrize('mux_class', [
     functools.partial(pescador.mux.Mux, with_replacement=True),
-    functools.partial(pescador.mux.PoissonMux, mode='with_replacement')],
+    functools.partial(pescador.mux.StochasticMux, mode='with_replacement')],
     ids=["DeprecatedMux",
-         "PoissonMux"])
-class TestPoissonMux_WithReplacement:
+         "StochasticMux"])
+class TestStochasticMux_WithReplacement:
     @pytest.mark.parametrize('n_streams', [1, 2, 4])
     @pytest.mark.parametrize('n_samples', [10, 20, 80])
     @pytest.mark.parametrize('n_active', [1, 2, 4])
@@ -322,12 +322,12 @@ class TestPoissonMux_WithReplacement:
         assert len(result) == n_samples
 
 
-class TestPoissonMux_Exhaustive:
+class TestStochasticMux_Exhaustive:
     @pytest.mark.parametrize('mux_class', [
         functools.partial(pescador.mux.Mux, with_replacement=False),
-        functools.partial(pescador.mux.PoissonMux, mode="exhaustive")],
+        functools.partial(pescador.mux.StochasticMux, mode="exhaustive")],
         ids=["DeprecatedMux",
-             "PoissonMux-exhaustive"])
+             "StochasticMux-exhaustive"])
     @pytest.mark.parametrize('weight', [0.0, 0.5])
     def test_mux_weighted(self, weight, mux_class):
         reference = list(T.finite_generator(50))
@@ -344,9 +344,9 @@ class TestPoissonMux_Exhaustive:
 
     @pytest.mark.parametrize('mux_class', [
         functools.partial(pescador.mux.Mux, with_replacement=False),
-        functools.partial(pescador.mux.PoissonMux, mode="exhaustive")],
+        functools.partial(pescador.mux.StochasticMux, mode="exhaustive")],
         ids=["DeprecatedMux",
-             "PoissonMux-exhaustive"])
+             "StochasticMux-exhaustive"])
     @pytest.mark.parametrize('weight', ([1e10, 1e-10],))
     def test_mux_rare(self, weight, mux_class):
         "This should give us all the reference before all the noise"
@@ -362,10 +362,10 @@ class TestPoissonMux_Exhaustive:
     @pytest.mark.parametrize('mux_class', [
         functools.partial(pescador.mux.Mux, k=2, with_replacement=False,
                           rate=None),
-        functools.partial(pescador.mux.PoissonMux,
+        functools.partial(pescador.mux.StochasticMux,
                           n_active=2, mode="exhaustive", rate=None)],
         ids=["DeprecatedMux",
-             "PoissonMux-exhaustive"])
+             "StochasticMux-exhaustive"])
     def test_weighted_empty_streams(self, mux_class):
 
         def __empty():
@@ -387,9 +387,9 @@ class TestPoissonMux_Exhaustive:
     @pytest.mark.parametrize('mux_class', [
         functools.partial(pescador.mux.Mux,
                           with_replacement=False, revive=False),
-        functools.partial(pescador.mux.PoissonMux, mode="exhaustive")],
+        functools.partial(pescador.mux.StochasticMux, mode="exhaustive")],
         ids=["DeprecatedMux",
-             "PoissonMux"])
+             "StochasticMux"])
     def test_critical_mux(self, mux_class):
         """This test checks the following:
 
@@ -415,9 +415,9 @@ class TestPoissonMux_Exhaustive:
     @pytest.mark.parametrize('mux_class', [
         functools.partial(pescador.mux.Mux,
                           with_replacement=False, revive=False),
-        functools.partial(pescador.mux.PoissonMux, mode="exhaustive")],
+        functools.partial(pescador.mux.StochasticMux, mode="exhaustive")],
         ids=["DeprecatedMux",
-             "PoissonMux"])
+             "StochasticMux"])
     def test_sampled_mux_of_muxes(self, mux_class):
         # Build some sample streams
         ab = pescador.Streamer(_cycle, 'ab')
@@ -453,10 +453,10 @@ class TestPoissonMux_Exhaustive:
 @pytest.mark.parametrize('mux_class', [
     functools.partial(pescador.mux.Mux,
                       with_replacement=False, revive=True),
-    functools.partial(pescador.mux.PoissonMux, mode="single_active")],
+    functools.partial(pescador.mux.StochasticMux, mode="single_active")],
     ids=["DeprecatedMux",
-         "PoissonMux"])
-class TestPoissonMux_SingleActive:
+         "StochasticMux"])
+class TestStochasticMux_SingleActive:
     @pytest.mark.parametrize('n_streams', [1, 2, 4])
     @pytest.mark.parametrize('n_samples', [512])
     @pytest.mark.parametrize('k', [1, 2, 4])


### PR DESCRIPTION
I also took the liberty of updating some docs to use `StochasticMux` where they were still using the old `Mux`.