### PR TITLE
fixed #127, target axis on buffer_stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
     - pip install -e .[tests]
 
 script:
-    - py.test -v --cov-report= --cov=pescador tests/
+    - pytest
 
 after_success:
     - coveralls

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -11,7 +11,7 @@ conda_create ()
     conda update -q conda
     conda config --add channels pypi
     conda info -a
-    deps='pip numpy scipy pytest pyzmq scikit-learn'
+    deps='pip numpy scipy pyzmq'
 
     conda create -q -n $ENV_NAME "python=$TRAVIS_PYTHON_VERSION" $deps
 }
@@ -31,8 +31,6 @@ if [ ! -f "$HOME/env/miniconda.sh" ]; then
         conda_create
 
         source activate $ENV_NAME
-
-        pip install python-coveralls pytest-cov
 
         source deactivate
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+addopts = --cov-report term-missing --cov pescador

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
     extras_require={
         'docs': ['numpydoc>=0.6',
                  'sphinx-gallery>=0.1.10'],
-        'tests': ['pytest-timeout>=1.2']
+        'tests': ['pytest', 'pytest-timeout>=1.2', 'pytest-cov']
     }
 )


### PR DESCRIPTION
This PR adds `axis` parameters to `buffer_stream` and `__stack_data`.  These can be used to prevent buffering from adding new axes to already buffered data, eg when batching up from batches.

I also removed an unused import.

This should be good to go, I think!