### PR TITLE
[RFC] bugfix ShuffledMux with integer weights

### DIFF
--- a/pescador/mux.py
+++ b/pescador/mux.py
@@ -873,7 +873,7 @@ class ShuffledMux(BaseMux):
         self.weights = weights
         if self.weights is None:
             self.weights = 1. / self.n_streams * np.ones(self.n_streams)
-        self.weights = np.atleast_1d(self.weights)
+        self.weights = np.atleast_1d(self.weights).astype('float')
 
         if len(self.weights) != len(self.streamers):
             raise PescadorError('`weights` must be the same '

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
     extras_require={
         'docs': ['numpydoc>=0.6',
                  'sphinx-gallery>=0.1.10'],
-        'tests': ['pytest', 'pytest-timeout>=1.2', 'pytest-cov']
+        'tests': ['pytest<=4.6', 'pytest-timeout>=1.2', 'pytest-cov']
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
     extras_require={
         'docs': ['numpydoc>=0.6',
                  'sphinx-gallery>=0.1.10'],
-        'tests': ['pytest<=4.6', 'pytest-timeout>=1.2', 'pytest-cov']
+        'tests': ['pytest<=4.0', 'pytest-timeout>=1.2', 'pytest-cov']
     }
 )

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -678,8 +678,18 @@ class TestShuffledMux:
             np.testing.assert_approx_equal(counter[key] / len(samples),
                                            weights[i],
                                            significant=1)
+            
+    def test_shuffled_mux_integer_weights(self):
+        "Tests that integer-valued weights are supported (issue #143)."
+        a = pescador.Streamer(_cycle, 'a')
+        b = pescador.Streamer(_cycle, 'b') 
+        c = pescador.Streamer(_cycle, 'c')
 
-
+        weights = [6, 3, 1]
+        mux = pescador.ShuffledMux([a, b, c], weights=weights, random_state=10)
+        assert "".join(list(mux.iterate(max_iter=20))) == 'babbaaabaabcaabbbacb'
+        
+    
 class TestRoundRobinMux:
     """The RoundRobinMux is guaranteed to reproduce samples in the
     same order as original streams.

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -685,9 +685,17 @@ class TestShuffledMux:
         b = pescador.Streamer(_cycle, 'b') 
         c = pescador.Streamer(_cycle, 'c')
 
-        weights = [6, 3, 1]
-        mux = pescador.ShuffledMux([a, b, c], weights=weights, random_state=10)
-        assert "".join(list(mux.iterate(max_iter=20))) == 'babbaaabaabcaabbbacb'
+        int_weights = [6, 3, 1]
+        int_mux = pescador.ShuffledMux(
+            [a, b, c], weights=int_weights, random_state=10)
+        int_seq = "".join(list(int_mux.iterate(max_iter=20)))
+     
+        float_weights = [6.0, 3.0, 1.0]
+        float_mux = pescador.ShuffledMux(
+            [a, b, c], weights=float_weights, random_state=10)
+        float_seq = "".join(list(float_mux.iterate(max_iter=20)))
+        
+        assert int_seq == float_seq
         
     
 class TestRoundRobinMux:


### PR DESCRIPTION
Fixes #143

I wrote the (failing) test `test_shuffled_mux_integer_weights`. I will write the bugfix once i make sure that this test reproduces issue #143.