### PR TITLE
Decorator interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These use cases arise in the following common scenarios:
   Pescador makes it easy to interleave these sources while maintaining a small `working set`.
   Not all sources are simultaneously active, but Pescador manages the working set so you don't have to.
 
-- If loading data incurs substantial latency (e.g., due to accessing storage access
+- If loading data incurs substantial latency (e.g., due to accessing on-disk storage
   or pre-processing), this can be a problem.
   
   Pescador can seamlessly move data generation into a background process, so that your main thread can continue working.

--- a/pescador/core.py
+++ b/pescador/core.py
@@ -8,6 +8,8 @@ import copy
 import inspect
 import six
 
+from decorator import decorator
+
 from .exceptions import PescadorError
 
 
@@ -262,3 +264,34 @@ class Streamer(object):
 
     def __iter__(self):
         return self.iterate()
+
+
+@decorator
+def streamable(function, *args, **kwargs):
+    '''Create a Streamer object by decoration.
+
+    This is a convenient shortcut for declaring generator
+    functions as Streamable, rather than having to construct
+    object wrappers explicitly every time.
+
+    Examples
+    --------
+    This example constructs a generator and then wraps it
+    in a Streamer object:
+
+    >>> def myfunc(n):
+    ...     for i in range(n):
+    ...         yield i
+    >>> s1 = Streamer(myfunc, 5)
+
+    Equivalently, you can use the decorator to achieve the
+    same effect:
+
+    >>> @pescador.streamable
+    ... def myfunc2(n):
+    ...     for i in range(n):
+    ...         yield i
+    >>> s2 = myfunc2(5)
+    '''
+
+    return Streamer(function, *args, **kwargs)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -272,3 +272,16 @@ def test_streamer_context_multiple_copies():
     result2 = list(gen2)
     assert len(result2) == 6
     assert streamer.active == 0
+
+
+def test_decorator():
+
+    @pescador.streamable
+    def my_generator(n):
+        for i in range(n):
+            yield i
+
+    s = my_generator(5)
+    assert isinstance(s, pescador.Streamer)
+    assert list(s) == [0, 1, 2, 3, 4]
+


### PR DESCRIPTION
This PR implements #129 

@ejhumphrey please give this a glance.  Tests pass and it behaves as expected.  I changed your implementation a little bit by using the `decorator` module.  This way, docstrings and call signatures are preserved:

```python
@pescador.streamable
def mystream(n):
    '''My bologna
    
    Docstring bonanza!
    '''
    for i in range(n):
        yield i
        
        
def streamable(func):
    def streamed(*args, **kwargs):
        return pescador.Streamer(func, *args, **kwargs)
    return streamed

@streamable
def mystream2(n):
    '''My bologna
    
    No docstring in sight.
    '''
    for i in range(n):
        yield i
```

results in
```python
[6]: mystream?
Signature: mystream(n)
Docstring:
My bologna

Docstring bonanza!
File:      ~/Notebooks/<ipython-input-5-0930abf6a0b9>
Type:      function
```

```python
[7]: mystream2?
Signature: mystream2(*args, **kwargs)
Docstring: <no docstring>
File:      ~/Notebooks/<ipython-input-5-0930abf6a0b9>
Type:      function
```