### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,8 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
+    - "3.7"
+    - "3.8"
 
 before_install:
     - bash .travis_dependencies.sh

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     keywords='machine learning',
     license='ISC',


### PR DESCRIPTION
Python 3.8 was released in October 2019.

And the Travis workaround for 3.7+ is no longer needed because Xenial is now the default.
