### PR TITLE
JSON->Msgpack

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - pyzmq>=18.0
   - decorator>=4.0
+  - msgpack-python>=1.0
 
   # optional, but required for testing
   - pytest

--- a/.github/environment-minimal.yml
+++ b/.github/environment-minimal.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - pyzmq~=18.0
   - decorator~=4.0
+  - msgpack-python~=1.0
 
   # optional, but required for testing
   - pytest

--- a/pescador/zmq_stream.py
+++ b/pescador/zmq_stream.py
@@ -16,11 +16,7 @@ The `ZMQStreamer` object wraps ordinary streamers (or muxes) for background exec
 import multiprocessing as mp
 import zmq
 import numpy as np
-
-try:
-    import ujson as json
-except ImportError:
-    import json
+import msgpack
 
 from .core import Streamer
 from .exceptions import DataError
@@ -51,7 +47,7 @@ def zmq_send_data(socket, data, flags=0, copy=True, track=False):
         payload.append(arr)
 
     # Send the header
-    msg = [json.dumps(header).encode("ascii")]
+    msg = [msgpack.packb(header)]
     msg.extend(payload)
 
     return socket.send_multipart(msg, flags, copy=copy, track=track)
@@ -63,7 +59,7 @@ def zmq_recv_data(socket, flags=0, copy=True, track=False):
 
     msg = socket.recv_multipart(flags=flags, copy=copy, track=track)
 
-    headers = json.loads(msg[0].decode("ascii"))
+    headers = msgpack.unpackb(msg[0], raw=False)
 
     if len(headers) == 0:
         raise StopIteration

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     pyzmq >= 18.0
     numpy >= 1.9
     decorator >= 4.0
+    msgpack >= 1.0
 
 [options.extras_require]
 docs = 


### PR DESCRIPTION
This PR replaces json serialization in ZMQ streamer with msgpack.

This is only for the array header data still, and not the actual contents of the shared data, but it's a step toward faster / better IPC.